### PR TITLE
Refactor workflows into one for deployment and one for testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
 name: Deploy to GitHub Pages
 
-on: push
+on:
+  push:
+    branches:
+      - 'main'
 
 jobs:
-  build_site:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -14,26 +17,23 @@ jobs:
           node-version-file: 'package.json' # Uses the node version specified under "engines"
       - name: Install dependencies
         run: npm install
-      - name: Read CNAME into variable
+      - name: Read custom domain into variable
         uses: guibranco/github-file-reader-action-v2@latest
-        id: read_cname
+        id: read_custom_domain
         with:
           path: 'static/CNAME'
-      - name: build
-        env:
-          #BASE_PATH: '/${{ github.event.repository.name }}'
-          BASE_PATH: ''
-          PUBLIC_BASE_URL: 'https://${{ steps.read_cname.outputs.contents }}'
+      - name: Build
         run: npm run build
+        env:
+          BASE_PATH: '' # Empty since we're deploying to the root url of our domain
+          PUBLIC_BASE_URL: 'https://${{ steps.read_custom_domain.outputs.contents }}'
       - name: Upload Artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          # this should match the `pages` option in your adapter-static options
-          path: 'build/'
+          path: 'build/' # Should match the "pages" option in the adapter-static options
   deploy:
-    if: github.ref == 'refs/heads/main'
-    needs: build_site
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/verify_branch_quality.yml
+++ b/.github/workflows/verify_branch_quality.yml
@@ -1,0 +1,27 @@
+name: Verify branch quality
+# Verifies that a branch is of sufficient quality to be merged into main
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+
+jobs:
+  verify-buildability:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json' # Uses the node version specified under "engines"
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+        env:
+          # These can be whatever since this is just a test build
+          BASE_PATH: ''
+          PUBLIC_BASE_URL: 'https://fake.url'

--- a/.github/workflows/verify_branch_quality.yml
+++ b/.github/workflows/verify_branch_quality.yml
@@ -25,3 +25,16 @@ jobs:
           # These can be whatever since this is just a test build
           BASE_PATH: ''
           PUBLIC_BASE_URL: 'https://fake.url'
+  verify-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json' # Uses the node version specified under "engines"
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
This PR refactors the GitHub Actions workflows so that there's one for deploying the site and one for testing the quality of branches that are not main.

The rationale for doing this is specified in issue #41.