### PR TITLE
Configure formatter and linter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   build:
@@ -14,23 +14,23 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'package.json' # Uses the node version specified under "engines"
+          node-version-file: "package.json" # Uses the node version specified under "engines"
       - name: Install dependencies
         run: npm install
       - name: Read custom domain into variable
         uses: guibranco/github-file-reader-action-v2@latest
         id: read_custom_domain
         with:
-          path: 'static/CNAME'
+          path: "static/CNAME"
       - name: Build
         run: npm run build
         env:
-          BASE_PATH: '' # Empty since we're deploying to the root url of our domain
-          PUBLIC_BASE_URL: 'https://${{ steps.read_custom_domain.outputs.contents }}'
+          BASE_PATH: "" # Empty since we're deploying to the root url of our domain
+          PUBLIC_BASE_URL: "https://${{ steps.read_custom_domain.outputs.contents }}"
       - name: Upload Artifacts
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'build/' # Should match the "pages" option in the adapter-static options
+          path: "build/" # Should match the "pages" option in the adapter-static options
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/verify_branch_quality.yml
+++ b/.github/workflows/verify_branch_quality.yml
@@ -3,8 +3,8 @@ name: Verify branch quality
 on:
   push:
     branches:
-      - '**'
-      - '!main'
+      - "**"
+      - "!main"
 
 jobs:
   verify-buildability:
@@ -15,15 +15,15 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'package.json' # Uses the node version specified under "engines"
+          node-version-file: "package.json" # Uses the node version specified under "engines"
       - name: Install dependencies
         run: npm install
       - name: Build
         run: npm run build
         env:
           # These can be whatever since this is just a test build
-          BASE_PATH: ''
-          PUBLIC_BASE_URL: 'https://fake.url'
+          BASE_PATH: ""
+          PUBLIC_BASE_URL: "https://fake.url"
   verify-formatting:
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +32,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'package.json' # Uses the node version specified under "engines"
+          node-version-file: "package.json" # Uses the node version specified under "engines"
       - name: Install dependencies
         run: npm install
       - name: Lint

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,26 @@
 {
-	"useTabs": true,
-	"singleQuote": true,
-	"trailingComma": "none",
 	"printWidth": 100,
+	"useTabs": true,
+	"semi": true,
+	"singleQuote": false,
+	"quoteProps": "consistent",
+	"trailingComma": "all",
+	"bracketSpacing": true,
+	"objectWrap": "preserve",
+	"bracketSameLine": false,
+	"arrowParens": "always",
+	"requirePragma": false,
+	"insertPragma": false,
+	"checkIgnorePragma": false,
+	"proseWrap": "preserve",
+	"htmlWhitespaceSensitivity": "css",
+	"embeddedLanguageFormatting": "auto",
+	"singleAttributePerLine": false,
+
+	"svelteSortOrder": "options-scripts-markup-styles",
+	"svelteAllowShorthand": true,
+	"svelteIndentScriptAndStyle": true,
+
 	"plugins": ["prettier-plugin-svelte"],
 	"overrides": [
 		{

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,5 +36,15 @@ export default ts.config(
 				svelteConfig
 			}
 		}
+	},
+	{
+		rules: {
+			"eqeqeq": "error",
+			"no-unneeded-ternary": "error",
+			"prefer-spread": "error",
+
+			// Stops us from accidentally triggering a security vulnerability in older browsers
+			"svelte/no-target-blank": "error"
+		}
 	}
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,13 @@
-import prettier from 'eslint-config-prettier';
-import { includeIgnoreFile } from '@eslint/compat';
-import js from '@eslint/js';
-import svelte from 'eslint-plugin-svelte';
-import globals from 'globals';
-import { fileURLToPath } from 'node:url';
-import ts from 'typescript-eslint';
-import svelteConfig from './svelte.config.js';
+import prettier from "eslint-config-prettier";
+import { includeIgnoreFile } from "@eslint/compat";
+import js from "@eslint/js";
+import svelte from "eslint-plugin-svelte";
+import globals from "globals";
+import { fileURLToPath } from "node:url";
+import ts from "typescript-eslint";
+import svelteConfig from "./svelte.config.js";
 
-const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
+const gitignorePath = fileURLToPath(new URL("./.gitignore", import.meta.url));
 
 export default ts.config(
 	includeIgnoreFile(gitignorePath),
@@ -18,24 +18,24 @@ export default ts.config(
 	...svelte.configs.prettier,
 	{
 		languageOptions: {
-			globals: { ...globals.browser, ...globals.node }
+			globals: { ...globals.browser, ...globals.node },
 		},
 		rules: {
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-			'no-undef': 'off'
-		}
+			"no-undef": "off",
+		},
 	},
 	{
-		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
+		files: ["**/*.svelte", "**/*.svelte.ts", "**/*.svelte.js"],
 		languageOptions: {
 			parserOptions: {
 				projectService: true,
-				extraFileExtensions: ['.svelte'],
+				extraFileExtensions: [".svelte"],
 				parser: ts.parser,
-				svelteConfig
-			}
-		}
+				svelteConfig,
+			},
+		},
 	},
 	{
 		rules: {
@@ -44,7 +44,7 @@ export default ts.config(
 			"prefer-spread": "error",
 
 			// Stops us from accidentally triggering a security vulnerability in older browsers
-			"svelte/no-target-blank": "error"
-		}
-	}
+			"svelte/no-target-blank": "error",
+		},
+	},
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,7 +39,6 @@ export default ts.config(
 	},
 	{
 		rules: {
-			"eqeqeq": "error",
 			"no-unneeded-ternary": "error",
 			"prefer-spread": "error",
 

--- a/src/lib/api/member.ts
+++ b/src/lib/api/member.ts
@@ -1,13 +1,13 @@
 import request from "./request";
 
 function createMember(firstName: string, lastName: string, email: string, isStudent: boolean) {
-    const data = {
-        "first_name": firstName,
-        "last_name": lastName,
-        "email": email,
-        "is_student": isStudent,
-    };
-    return request("members/", "post", data);
+	const data = {
+		first_name: firstName,
+		last_name: lastName,
+		email: email,
+		is_student: isStudent,
+	};
+	return request("members/", "post", data);
 }
 
 export { createMember };

--- a/src/lib/api/request.ts
+++ b/src/lib/api/request.ts
@@ -5,21 +5,21 @@ const DEVELOPMENT_URL = "http://localhost:8000/";
 const PRODUCTION_URL = "https://lithehax-medlem-9abc9f434ec7.herokuapp.com/";
 
 const instance = axios.create({
-  baseURL: dev ? DEVELOPMENT_URL : PRODUCTION_URL,
-  timeout: 10000,
-  headers: { "Content-Type": "application/json" },
+	baseURL: dev ? DEVELOPMENT_URL : PRODUCTION_URL,
+	timeout: 10000,
+	headers: { "Content-Type": "application/json" },
 });
 
 type Method = "get" | "post" | "put" | "patch" | "delete" | "head" | "options";
-type Json = [any] | { [key: string]: any };
+type Json = unknown[] | { [key: string]: unknown };
 
 function request(url: string, method: Method, data?: Json) {
-  return instance.request({
-    url: url,
-    method: method,
-    data: data,
-    responseType: "json",
-  });
+	return instance.request({
+		url: url,
+		method: method,
+		data: data,
+		responseType: "json",
+	});
 }
 
 export default request;

--- a/src/lib/components/ContactCard.svelte
+++ b/src/lib/components/ContactCard.svelte
@@ -1,70 +1,70 @@
 <script lang="ts">
-    type Props = {
-        fullName: string,
-        hackerTag: string,
-        position: string,
-        email?: string,
-        image?: string,
-    };
-    let { fullName, hackerTag, position, email, image }: Props = $props();
+	type Props = {
+		fullName: string;
+		hackerTag: string;
+		position: string;
+		email?: string;
+		image?: string;
+	};
+	let { fullName, hackerTag, position, email, image }: Props = $props();
 
-    import placeholderImg from "$lib/images/contacts/placeholder.png";
+	import placeholderImg from "$lib/images/contacts/placeholder.png";
 </script>
 
 <div class="contact-card">
-    <img src={image !== undefined ? image : placeholderImg} alt={fullName} />
-    <div class="info">
-        <span class="name">{fullName} @{hackerTag}</span>
-        <span class="position">{position}</span>
-        {#if email !== undefined}
-            <a class="email" href={`mailto:${email}`}>{email}</a>
-        {:else}
-            <span class="email">(mail coming soon)</span>
-        {/if}
-    </div>
+	<img src={image !== undefined ? image : placeholderImg} alt={fullName} />
+	<div class="info">
+		<span class="name">{fullName} @{hackerTag}</span>
+		<span class="position">{position}</span>
+		{#if email !== undefined}
+			<a class="email" href={`mailto:${email}`}>{email}</a>
+		{:else}
+			<span class="email">(mail coming soon)</span>
+		{/if}
+	</div>
 </div>
 
 <style>
-    .contact-card {
-        display: flex;
-        flex-direction: row;
-        gap: 0.5rem;
-    }
+	.contact-card {
+		display: flex;
+		flex-direction: row;
+		gap: 0.5rem;
+	}
 
-    img {
-        width: 8rem;
-        height: 8rem;
-        border-radius: 50%;
-    }
+	img {
+		width: 8rem;
+		height: 8rem;
+		border-radius: 50%;
+	}
 
-    .info {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        min-width: 0; /* Makes info box take only remaining space when small */
-    }
+	.info {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		min-width: 0; /* Makes info box take only remaining space when small */
+	}
 
-    .name {
-        color: var(--heading-fg);
-        font-size: 1.175em;
-        font-weight: bold;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
+	.name {
+		color: var(--heading-fg);
+		font-size: 1.175em;
+		font-weight: bold;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 
-    .position {
-        margin-bottom: 1em;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
+	.position {
+		margin-bottom: 1em;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 
-    .email {
-        /* Clamps the boundaries of the link */
-        width: 100%;
-        align-self: flex-start;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
+	.email {
+		/* Clamps the boundaries of the link */
+		width: 100%;
+		align-self: flex-start;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 
-    /* Email link is also styled by the global stylesheet */
+	/* Email link is also styled by the global stylesheet */
 </style>

--- a/src/lib/components/DocumentLink.svelte
+++ b/src/lib/components/DocumentLink.svelte
@@ -1,36 +1,36 @@
 <script lang="ts">
-    type Props = { link: string };
-    let { link }: Props = $props();
+	type Props = { link: string };
+	let { link }: Props = $props();
 
-    function deriveLabel() {
-        let splitLink = link.split("/");
-        return splitLink[splitLink.length - 1];
-    }
+	function deriveLabel() {
+		let splitLink = link.split("/");
+		return splitLink[splitLink.length - 1];
+	}
 
-    const label = $derived(deriveLabel());
-    const icon = "📄"; // TODO: switch to SVG?
+	const label = $derived(deriveLabel());
+	const icon = "📄"; // TODO: switch to SVG?
 </script>
 
 <span>
-    <a href={link}>
-        <span class="icon">{icon}</span>
-        <span class="label">{label}</span>
-    </a>
+	<a href={link}>
+		<span class="icon">{icon}</span>
+		<span class="label">{label}</span>
+	</a>
 </span>
 
 <style>
-    a {
-        display: inline-flex;
-        flex-direction: row;
-        gap: 0.2ch;
-        align-items: center;
-        color: var(--link-btn-fg);
-        text-decoration: none;
-    }
+	a {
+		display: inline-flex;
+		flex-direction: row;
+		gap: 0.2ch;
+		align-items: center;
+		color: var(--link-btn-fg);
+		text-decoration: none;
+	}
 
-    .label {
-        padding: 0.2em;
-        border-radius: 0.2rem;
-        background-color: var(--link-btn-bg);
-    }
+	.label {
+		padding: 0.2em;
+		border-radius: 0.2rem;
+		background-color: var(--link-btn-bg);
+	}
 </style>

--- a/src/lib/components/FormField.svelte
+++ b/src/lib/components/FormField.svelte
@@ -1,118 +1,119 @@
 <script lang="ts">
-    import type { Snippet } from "svelte";
+	import type { Snippet } from "svelte";
 
-    type InputType = "text" | "email" | "select" | "submit";
-    type Props = {
-        name: string,
-        label: string,
-        type: InputType,
-        required?: boolean,
-        error?: string,
-        children?: Snippet,
-    };
-    let { name, label, type, required = false, error, children }: Props = $props();
+	type InputType = "text" | "email" | "select" | "submit";
+	type Props = {
+		name: string;
+		label: string;
+		type: InputType;
+		required?: boolean;
+		error?: string;
+		children?: Snippet;
+	};
+	let { name, label, type, required = false, error, children }: Props = $props();
 </script>
 
-<div class={`field${error !== undefined ? " error": ""}`}>
-    <label for={name}>{label}</label>
+<div class={`field${error !== undefined ? " error" : ""}`}>
+	<label for={name}>{label}</label>
 
-    <div class="input-container">
-        {#if type === "text"}
-            <input id={name} name={name} type="text" required={required} />
-        {:else if type === "email"}
-            <input id={name} name={name} type="email" required={required} />
-        {:else if type === "select"}
-            <select id={name} name={name} required={required}>
-                {#if children !== undefined}
-                    {@render children()}
-                {/if}
-            </select>
-        {:else}
-            <span>UNSUPPORTED INPUT FIELD</span>
-        {/if}
+	<div class="input-container">
+		{#if type === "text"}
+			<input id={name} {name} type="text" {required} />
+		{:else if type === "email"}
+			<input id={name} {name} type="email" {required} />
+		{:else if type === "select"}
+			<select id={name} {name} {required}>
+				{#if children !== undefined}
+					{@render children()}
+				{/if}
+			</select>
+		{:else}
+			<span>UNSUPPORTED INPUT FIELD</span>
+		{/if}
 
-        {#if error !== undefined}
-            <div class="error-tooltip">
-                <span>{error}</span>
-            </div>
-        {/if}
-    </div>
+		{#if error !== undefined}
+			<div class="error-tooltip">
+				<span>{error}</span>
+			</div>
+		{/if}
+	</div>
 </div>
 
 <style>
-    .field {
-        display: inline-flex;
-        flex-direction: column;
-    }
+	.field {
+		display: inline-flex;
+		flex-direction: column;
+	}
 
-    label {
-        align-self: flex-start;
-        color: var(--input-label-fg);
-    }
+	label {
+		align-self: flex-start;
+		color: var(--input-label-fg);
+	}
 
-    input, select {
-        box-sizing: border-box;
-        width: 100%;
-        padding: 0.5rem;
-        border: 1px solid var(--input-border);
-        border-radius: 0.25rem;
-        background-color: var(--input-bg);
-        color: var(--input-fg);
-        box-shadow: inset 0 1px 3px 1px var(--input-shadow);
-    }
+	input,
+	select {
+		box-sizing: border-box;
+		width: 100%;
+		padding: 0.5rem;
+		border: 1px solid var(--input-border);
+		border-radius: 0.25rem;
+		background-color: var(--input-bg);
+		color: var(--input-fg);
+		box-shadow: inset 0 1px 3px 1px var(--input-shadow);
+	}
 
-    .error input,
-    .error select {
-        border-color: var(--error-color);
-    }
+	.error input,
+	.error select {
+		border-color: var(--error-color);
+	}
 
-    .input-container {
-        position: relative;
-    }
+	.input-container {
+		position: relative;
+	}
 
-    .error-tooltip {
-        position: absolute;
-        bottom: calc(100% + 8px);
-        right: 0;
-        padding: 0.2rem 0.4rem;
-        border: 1px solid var(--error-color);
-        border-radius: 0.25rem;
-        background-color: var(--section-bg);
-        color: var(--section-fg);
-        opacity: 0;
-        visibility: hidden;
-        transition: all 100ms ease-out;
-    }
+	.error-tooltip {
+		position: absolute;
+		bottom: calc(100% + 8px);
+		right: 0;
+		padding: 0.2rem 0.4rem;
+		border: 1px solid var(--error-color);
+		border-radius: 0.25rem;
+		background-color: var(--section-bg);
+		color: var(--section-fg);
+		opacity: 0;
+		visibility: hidden;
+		transition: all 100ms ease-out;
+	}
 
-    .input-container:hover .error-tooltip {
-        opacity: 1;
-        visibility: visible;
-    }
+	.input-container:hover .error-tooltip {
+		opacity: 1;
+		visibility: visible;
+	}
 
-    input:focus ~ .error-tooltip {
-        opacity: 1;
-        visibility: visible;
-    }
+	input:focus ~ .error-tooltip {
+		opacity: 1;
+		visibility: visible;
+	}
 
-    .error-tooltip::after {
-        content: "";
-        position: absolute;
-        top: 100%;
-        left: 25%;
-        border: 8px solid var(--section-bg);
-        border-right-color: transparent;
-        border-bottom-color: transparent;
-        border-left-color: transparent;
-    }
+	.error-tooltip::after {
+		content: "";
+		position: absolute;
+		top: 100%;
+		left: 25%;
+		border: 8px solid var(--section-bg);
+		border-right-color: transparent;
+		border-bottom-color: transparent;
+		border-left-color: transparent;
+	}
 
-    .error-tooltip::before {
-        content: "";
-        position: absolute;
-        top: calc(100% + 1px);
-        left: 25%;
-        border: 8px solid var(--error-color);
-        border-right-color: transparent;
-        border-bottom-color: transparent;
-        border-left-color: transparent;
-    }
+	.error-tooltip::before {
+		content: "";
+		position: absolute;
+		top: calc(100% + 1px);
+		left: 25%;
+		border: 8px solid var(--error-color);
+		border-right-color: transparent;
+		border-bottom-color: transparent;
+		border-left-color: transparent;
+	}
 </style>

--- a/src/lib/components/FormSubmit.svelte
+++ b/src/lib/components/FormSubmit.svelte
@@ -1,33 +1,33 @@
 <script lang="ts">
-    import type { Snippet } from "svelte";
+	import type { Snippet } from "svelte";
 
-    type Props = { disabled?: boolean, children?: Snippet };
-    let { disabled = false, children }: Props = $props();
+	type Props = { disabled?: boolean; children?: Snippet };
+	let { disabled = false, children }: Props = $props();
 </script>
 
-<button type="submit" disabled={disabled}>
-    {#if children !== undefined}
-        {@render children()}
-    {/if}
+<button type="submit" {disabled}>
+	{#if children !== undefined}
+		{@render children()}
+	{/if}
 </button>
 
 <style>
-    button {
-        padding: 0.5rem;
-        border: 0;
-        border-radius: 0.25rem;
-        background-color: var(--button-bg);
-        color: var(--button-fg);
-        box-shadow: 0 2px 4px 0 var(--button-shadow);
-        font-size: 1em;
-        font-weight: bold;
-        transform: scaley(1);
-        transition: all 150ms ease-out;
-    }
+	button {
+		padding: 0.5rem;
+		border: 0;
+		border-radius: 0.25rem;
+		background-color: var(--button-bg);
+		color: var(--button-fg);
+		box-shadow: 0 2px 4px 0 var(--button-shadow);
+		font-size: 1em;
+		font-weight: bold;
+		transform: scaley(1);
+		transition: all 150ms ease-out;
+	}
 
-    button:hover {
-        background-color: var(--button-hover-bg);
-        color: var(--button-hover-fg);
-        transform: scaley(1.1);
-    }
+	button:hover {
+		background-color: var(--button-hover-bg);
+		color: var(--button-hover-fg);
+		transform: scaley(1.1);
+	}
 </style>

--- a/src/lib/components/LayoutHeader.svelte
+++ b/src/lib/components/LayoutHeader.svelte
@@ -1,175 +1,193 @@
 <script lang="ts">
-    import logo from "$lib/images/header-logo.svg";
-    import { base } from "$app/paths";
+	import logo from "$lib/images/header-logo.svg";
+	import { base } from "$app/paths";
 
-    let navIsOpen = $state(false);
+	let navIsOpen = $state(false);
 
-    function toggleNav() {
-        navIsOpen = !navIsOpen;
-    }
+	function toggleNav() {
+		navIsOpen = !navIsOpen;
+	}
 </script>
 
 {#snippet hamburgerSvg()}
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M0 96C0 78.3 14.3 64 32 64l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 128C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 288c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32L32 448c-17.7 0-32-14.3-32-32s14.3-32 32-32l384 0c17.7 0 32 14.3 32 32z"/></svg>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+		<!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+		<path
+			d="M0 96C0 78.3 14.3 64 32 64l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 128C14.3 128 0 113.7 0 96zM0 256c0-17.7 14.3-32 32-32l384 0c17.7 0 32 14.3 32 32s-14.3 32-32 32L32 288c-17.7 0-32-14.3-32-32zM448 416c0 17.7-14.3 32-32 32L32 448c-17.7 0-32-14.3-32-32s14.3-32 32-32l384 0c17.7 0 32 14.3 32 32z"
+		/>
+	</svg>
 {/snippet}
 
 <header class="mobile">
-    <button onclick={toggleNav}>{@render hamburgerSvg()}</button>
-    <img src={logo} alt="logo" />
-    <button style="visibility: hidden;">{@render hamburgerSvg()}</button>
+	<button onclick={toggleNav}>{@render hamburgerSvg()}</button>
+	<img src={logo} alt="logo" />
+	<button style="visibility: hidden;">{@render hamburgerSvg()}</button>
 
-    <div class={"nav-backdrop " + (navIsOpen ? "open" : "closed")}
-        onclick={toggleNav} role="none"></div>
-    <nav class={navIsOpen ? "open" : "closed"}>
-        <a href={`${base}/`} onclick={toggleNav}>Home</a>
-        <a href={`${base}/new-member`} onclick={toggleNav}>Member</a>
-        <a href={`${base}/events`} onclick={toggleNav}>Events</a>
-    </nav>
+	<div
+		class={"nav-backdrop " + (navIsOpen ? "open" : "closed")}
+		onclick={toggleNav}
+		role="none"
+	></div>
+	<nav class={navIsOpen ? "open" : "closed"}>
+		<a href={`${base}/`} onclick={toggleNav}>Home</a>
+		<a href={`${base}/new-member`} onclick={toggleNav}>Member</a>
+		<a href={`${base}/events`} onclick={toggleNav}>Events</a>
+	</nav>
 </header>
 
 <header class="desktop">
-    <img src={logo} alt="logo" />
-    <nav>
-        <a href={`${base}/`}>Home</a>
-        <a href={`${base}/new-member`}>Member</a>
-        <a href={`${base}/events`}>Events</a>
-    </nav>
+	<img src={logo} alt="logo" />
+	<nav>
+		<a href={`${base}/`}>Home</a>
+		<a href={`${base}/new-member`}>Member</a>
+		<a href={`${base}/events`}>Events</a>
+	</nav>
 </header>
 
 <style>
-    /* Mobile styling */
-    @media screen and (min-width: 0px) {
-        .mobile { display: grid; }
-        .desktop { display: none; }
-    }
+	/* Mobile styling */
+	@media screen and (min-width: 0px) {
+		.mobile {
+			display: grid;
+		}
+		.desktop {
+			display: none;
+		}
+	}
 
-    .mobile {
-        /* Display included in media query */
-        grid-template-columns: max-content 1fr max-content;
-        grid-template-areas: "left" "logo" "right";
-        position: sticky;
-        top: 0;
-        /* z-index is needed since the transforms and relative positions
-           of certain elements in <main> mess with the stacking */
-        z-index: 1;
-        width: 100vw;
-        background-color: var(--header-bg);
-        color: var(--header-fg);
-    }
+	.mobile {
+		/* Display included in media query */
+		grid-template-columns: max-content 1fr max-content;
+		grid-template-areas: "left" "logo" "right";
+		position: sticky;
+		top: 0;
+		/* z-index is needed since the transforms and relative positions
+		   of certain elements in <main> mess with the stacking */
+		z-index: 1;
+		width: 100vw;
+		background-color: var(--header-bg);
+		color: var(--header-fg);
+	}
 
-    .mobile img {
-        margin: 0.5rem 0;
-        width: 100%;
-        height: 3rem;
-        justify-self: center;
-        align-self: center;
-    }
+	.mobile img {
+		margin: 0.5rem 0;
+		width: 100%;
+		height: 3rem;
+		justify-self: center;
+		align-self: center;
+	}
 
-    .mobile button {
-        display: flex;
-        align-items: center;
-        border: 0;
-        padding: 1rem;
-        background-color: transparent;
-    }
+	.mobile button {
+		display: flex;
+		align-items: center;
+		border: 0;
+		padding: 1rem;
+		background-color: transparent;
+	}
 
-    .mobile button svg {
-        height: 2rem;
-        fill: var(--header-fg);
-    }
+	.mobile button svg {
+		height: 2rem;
+		fill: var(--header-fg);
+	}
 
-    .mobile .nav-backdrop {
-        position: fixed;
-        top: 4rem;
-        left: 0;
-        bottom: 0;
-        right: 0;
-        background-color: rgba(0, 0, 0, 0.5);
-        transition: opacity 150ms, visibility 150ms ease;
-    }
+	.mobile .nav-backdrop {
+		position: fixed;
+		top: 4rem;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		background-color: rgba(0, 0, 0, 0.5);
+		transition:
+			opacity 150ms,
+			visibility 150ms ease;
+	}
 
-    .mobile .nav-backdrop.open {
-        opacity: 1;
-        visibility: visible;
-    }
+	.mobile .nav-backdrop.open {
+		opacity: 1;
+		visibility: visible;
+	}
 
-    .mobile .nav-backdrop.closed {
-        opacity: 0;
-        visibility: hidden;
-    }
+	.mobile .nav-backdrop.closed {
+		opacity: 0;
+		visibility: hidden;
+	}
 
-    .mobile nav {
-        display: flex;
-        flex-direction: column;
-        position: fixed;
-        top: 4rem;
-        bottom: 0;
-        min-width: 13rem; /* To not look ridiculously small */
-        background-color: var(--bg);
-        transition: transform 150ms ease;
-    }
+	.mobile nav {
+		display: flex;
+		flex-direction: column;
+		position: fixed;
+		top: 4rem;
+		bottom: 0;
+		min-width: 13rem; /* To not look ridiculously small */
+		background-color: var(--bg);
+		transition: transform 150ms ease;
+	}
 
-    .mobile nav.open {
-        transform: translateX(0%);
-    }
+	.mobile nav.open {
+		transform: translateX(0%);
+	}
 
-    .mobile nav.closed {
-        transform: translateX(-100%);
-    }
+	.mobile nav.closed {
+		transform: translateX(-100%);
+	}
 
-    .mobile nav a {
-        border-bottom: 3px solid rgba(0, 0, 0, 0.35);
-        padding: 1rem;
-        color: var(--header-fg);
-        line-height: 1;
-        font-weight: bold;
-        text-decoration: none;
-    }
+	.mobile nav a {
+		border-bottom: 3px solid rgba(0, 0, 0, 0.35);
+		padding: 1rem;
+		color: var(--header-fg);
+		line-height: 1;
+		font-weight: bold;
+		text-decoration: none;
+	}
 
-    /* Desktop styling */
-    @media screen and (min-width: 768px) {
-        .mobile { display: none; }
-        .desktop { display: flex; }
-    }
+	/* Desktop styling */
+	@media screen and (min-width: 768px) {
+		.mobile {
+			display: none;
+		}
+		.desktop {
+			display: flex;
+		}
+	}
 
-    .desktop {
-        /* Display included in media query */
-        flex-direction: column;
-        box-sizing: border-box;
-        padding: 2rem;
-        width: 100vw;
-        background-color: var(--header-bg);
-        color: var(--header-fg);
-    }
+	.desktop {
+		/* Display included in media query */
+		flex-direction: column;
+		box-sizing: border-box;
+		padding: 2rem;
+		width: 100vw;
+		background-color: var(--header-bg);
+		color: var(--header-fg);
+	}
 
-    .desktop img {
-        margin-bottom: 1.5rem;
-        max-width: 100%;
-        height: 4rem;
-    }
+	.desktop img {
+		margin-bottom: 1.5rem;
+		max-width: 100%;
+		height: 4rem;
+	}
 
-    .desktop nav {
-        display: flex;
-        flex-direction: row;
-        gap: 1rem;
-        justify-content: center;
-    }
+	.desktop nav {
+		display: flex;
+		flex-direction: row;
+		gap: 1rem;
+		justify-content: center;
+	}
 
-    .desktop nav a {
-        padding: 0.5rem 1rem;
-        border: 0.15rem solid var(--header-fg);
-        border-radius: 0.5rem;
-        background-color: var(--header-fg);
-        color: var(--header-bg);
-        line-height: 1;
-        font-weight: bold;
-        text-decoration: none;
-        transition: all 150ms ease-out;
-    }
+	.desktop nav a {
+		padding: 0.5rem 1rem;
+		border: 0.15rem solid var(--header-fg);
+		border-radius: 0.5rem;
+		background-color: var(--header-fg);
+		color: var(--header-bg);
+		line-height: 1;
+		font-weight: bold;
+		text-decoration: none;
+		transition: all 150ms ease-out;
+	}
 
-    .desktop nav a:hover {
-        background-color: var(--header-bg);
-        color: var(--header-fg);
-        transform: scale(1.1);
-    }
+	.desktop nav a:hover {
+		background-color: var(--header-bg);
+		color: var(--header-fg);
+		transform: scale(1.1);
+	}
 </style>

--- a/src/lib/components/PageHead.svelte
+++ b/src/lib/components/PageHead.svelte
@@ -1,27 +1,27 @@
 <script lang="ts">
 	import { PUBLIC_BASE_URL } from "$env/static/public";
-    import type { Snippet } from "svelte";
+	import type { Snippet } from "svelte";
 
-    type Props = {
-        children?: Snippet<[]>;
-        title: string;
-        description: string;
-    };
+	type Props = {
+		children?: Snippet<[]>;
+		title: string;
+		description: string;
+	};
 
-    const { children, title, description }: Props = $props();
-    const effectiveTitle = $derived(title ? `LiTHe Hax - ${title}` : 'LiTHe Hax');
+	const { children, title, description }: Props = $props();
+	const effectiveTitle = $derived(title ? `LiTHe Hax - ${title}` : "LiTHe Hax");
 </script>
 
 <svelte:head>
-    <title>{effectiveTitle}</title>
-    <meta name="description" content={description} />
-    <meta property="og:title" content={effectiveTitle} />
-    <meta property="og:description" content={description} />
-    <meta property="og:image" content="{PUBLIC_BASE_URL}/favicon.png">
-    <meta property="og:image:alt" content="LiTHe Hax">
-    <meta property="og:site_name" content="LiTHe Hax">
-    <meta property="og:type" content="website">
-    {#if children}
-        {@render children()}
-    {/if}
+	<title>{effectiveTitle}</title>
+	<meta name="description" content={description} />
+	<meta property="og:title" content={effectiveTitle} />
+	<meta property="og:description" content={description} />
+	<meta property="og:image" content="{PUBLIC_BASE_URL}/favicon.png" />
+	<meta property="og:image:alt" content="LiTHe Hax" />
+	<meta property="og:site_name" content="LiTHe Hax" />
+	<meta property="og:type" content="website" />
+	{#if children}
+		{@render children()}
+	{/if}
 </svelte:head>

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -1,47 +1,51 @@
 <script lang="ts">
-    import type { Snippet } from "svelte";
+	import type { Snippet } from "svelte";
 
-    type Props = { children: Snippet, isThin?: boolean };
-    let { children, isThin = false }: Props = $props();
+	type Props = { children: Snippet; isThin?: boolean };
+	let { children, isThin = false }: Props = $props();
 </script>
 
 <section class={isThin ? "thin" : ""}>
-    {@render children()}
+	{@render children()}
 </section>
 
 <style>
-    /* Mobile styling */
-    @media screen and (min-width: 0px) {
-        section {
-            margin: 1rem;
-            padding: 1rem;
-            border-radius: 0.5rem;
-            background-color: var(--section-bg);
-            color: var(--section-fg);
-        }
-    }
+	/* Mobile styling */
+	@media screen and (min-width: 0px) {
+		section {
+			margin: 1rem;
+			padding: 1rem;
+			border-radius: 0.5rem;
+			background-color: var(--section-bg);
+			color: var(--section-fg);
+		}
+	}
 
-    /* Desktop styling */
-    @media screen and (min-width: 768px) {
-        section {
-            margin: 3rem;
-            padding: 1.5rem;
-            border-radius: 0.5rem;
-            background-color: var(--section-bg);
-            color: var(--section-fg);
-        }
+	/* Desktop styling */
+	@media screen and (min-width: 768px) {
+		section {
+			margin: 3rem;
+			padding: 1.5rem;
+			border-radius: 0.5rem;
+			background-color: var(--section-bg);
+			color: var(--section-fg);
+		}
 
-        section.thin {
-            margin: 3rem auto;
-            max-width: min(36rem, calc(100% - 6rem)); /* Fakes a 3rem horizontal margin */
-        }
-    }
+		section.thin {
+			margin: 3rem auto;
+			max-width: min(36rem, calc(100% - 6rem)); /* Fakes a 3rem horizontal margin */
+		}
+	}
 
-    /* Ensures that there are no unnecessarily large gaps at top or bottom */
-    section > :global(:first-child) { margin-top: 0; }
-    section > :global(:last-child) { margin-bottom: 0; }
+	/* Ensures that there are no unnecessarily large gaps at top or bottom */
+	section > :global(:first-child) {
+		margin-top: 0;
+	}
+	section > :global(:last-child) {
+		margin-bottom: 0;
+	}
 
-    section > :global(:is(h1, h2, h3, h4, h5, h6)) {
-        color: var(--heading-fg);
-    }
+	section > :global(:is(h1, h2, h3, h4, h5, h6)) {
+		color: var(--heading-fg);
+	}
 </style>

--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -1,62 +1,62 @@
 :root {
-    --bg: #121212;
-    --fg: #ffffff;
-    --header-bg: #002200;
-    --header-fg: #33ff33;
-    --section-bg: #1a1a1a;
-    --section-fg: #ffffff;
+	--bg: #121212;
+	--fg: #ffffff;
+	--header-bg: #002200;
+	--header-fg: #33ff33;
+	--section-bg: #1a1a1a;
+	--section-fg: #ffffff;
 
-    --heading-fg: #33ff33;
+	--heading-fg: #33ff33;
 
-    --link-fg: #33ff33;
-    --link-hover-fg: #aaffbf;
+	--link-fg: #33ff33;
+	--link-hover-fg: #aaffbf;
 
-    --link-btn-bg: #333333;
-    --link-btn-fg: #ffffff;
+	--link-btn-bg: #333333;
+	--link-btn-fg: #ffffff;
 
-    --input-label-fg: #33ff33;
-    --input-bg: #333333;
-    --input-border: #444444;
-    --input-fg: #33ff33;
-    --input-shadow: #00000044;
-    --button-bg: #232323;
-    --button-fg: #33ff33;
-    --button-shadow: #00000044;
-    --button-hover-bg: var(--button-fg);
-    --button-hover-fg: var(--button-bg);
-    --success-color: #33ff33;
-    --error-color: #ff3333;
+	--input-label-fg: #33ff33;
+	--input-bg: #333333;
+	--input-border: #444444;
+	--input-fg: #33ff33;
+	--input-shadow: #00000044;
+	--button-bg: #232323;
+	--button-fg: #33ff33;
+	--button-shadow: #00000044;
+	--button-hover-bg: var(--button-fg);
+	--button-hover-fg: var(--button-bg);
+	--success-color: #33ff33;
+	--error-color: #ff3333;
 
-    --separator-color: grey;
+	--separator-color: grey;
 }
 
 body {
-    margin: 0;
-    padding: 0;
-    background-color: var(--bg);
-    color: var(--fg);
-    font-family: sans-serif;
+	margin: 0;
+	padding: 0;
+	background-color: var(--bg);
+	color: var(--fg);
+	font-family: sans-serif;
 }
 
 a {
-    color: var(--link-fg);
-    text-decoration: none;
-    transition: color 150ms ease-out;
-    fill: var(--link-fg);
+	color: var(--link-fg);
+	text-decoration: none;
+	transition: color 150ms ease-out;
+	fill: var(--link-fg);
 }
 
 a:hover {
-    color: var(--link-hover-fg);
-    fill: var(--link-hover-fg);
+	color: var(--link-hover-fg);
+	fill: var(--link-hover-fg);
 }
 
 a > svg {
-    fill: inherit;
-    transition: fill 150ms ease-out;
+	fill: inherit;
+	transition: fill 150ms ease-out;
 }
 
 hr {
-    border-color: var(--separator-color);
-    border-style: solid;
-    margin: 1rem 0;
+	border-color: var(--separator-color);
+	border-style: solid;
+	margin: 1rem 0;
 }

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -4,6 +4,6 @@ import { PUBLIC_BASE_URL } from "$env/static/public";
 export const prerender = true;
 
 export function load({ url }) {
-  const canonicalHref = `${PUBLIC_BASE_URL}${url.pathname}`;
-  return { canonicalHref };
+	const canonicalHref = `${PUBLIC_BASE_URL}${url.pathname}`;
+	return { canonicalHref };
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,21 +1,22 @@
 <script lang="ts">
-    import "$lib/styles/global.css"; // This stylesheet affects the entire site.
-    import LayoutHeader from "$lib/components/LayoutHeader.svelte";
+	import type { Snippet } from "svelte";
+	import "$lib/styles/global.css"; // This stylesheet affects the entire site.
+	import LayoutHeader from "$lib/components/LayoutHeader.svelte";
 
-    interface LayoutProps {
-        children: any;
-        data: {
-            canonicalHref: string;
-        };
-    }
+	interface LayoutProps {
+		children: Snippet;
+		data: {
+			canonicalHref: string;
+		};
+	}
 
-    // In Runes mode, we extract our data using $props()
-    let { children, data } = $props() as LayoutProps;
+	// In Runes mode, we extract our data using $props()
+	let { children, data } = $props() as LayoutProps;
 </script>
 
 <svelte:head>
-    <link rel="canonical" href="{data.canonicalHref}" />
-    <meta property="og:url" content="{data.canonicalHref}">
+	<link rel="canonical" href={data.canonicalHref} />
+	<meta property="og:url" content={data.canonicalHref} />
 </svelte:head>
 
 <LayoutHeader />
@@ -23,7 +24,7 @@
 <main>{@render children()}</main>
 
 <style>
-    main {
-        width: 100vw;
-    }
+	main {
+		width: 100vw;
+	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,157 +1,183 @@
 <script lang="ts">
-    import { base } from "$app/paths";
+	import { base } from "$app/paths";
 
-    import ContactCard from "$lib/components/ContactCard.svelte";
-    import DocumentLink from "$lib/components/DocumentLink.svelte";
-    import Section from "$lib/components/Section.svelte";
-    import PageHead from "$lib/components/PageHead.svelte";
+	import ContactCard from "$lib/components/ContactCard.svelte";
+	import DocumentLink from "$lib/components/DocumentLink.svelte";
+	import Section from "$lib/components/Section.svelte";
+	import PageHead from "$lib/components/PageHead.svelte";
 
-    import chairmanImg from "$lib/images/contacts/tyson_h.jpg";
-    import webmasterImg from "$lib/images/contacts/viktor_h.jpg";
-    import secretaryImg from "$lib/images/contacts/david_s.png";
-    import accountantImg from "$lib/images/contacts/adam_b.jpg";
-    import member1Img from "$lib/images/contacts/wilmer_s.jpg";
-    import member2Img from "$lib/images/contacts/tove_h.jpg";
-    import member3Img from "$lib/images/contacts/anton_o.jpg";
-    import member4Img from "$lib/images/contacts/william_m.jpg";
-    import member5Img from "$lib/images/contacts/tom_e.jpg";
-    import maskotImg from "$lib/images/contacts/torbjorn_h.png";
+	import chairmanImg from "$lib/images/contacts/tyson_h.jpg";
+	import webmasterImg from "$lib/images/contacts/viktor_h.jpg";
+	import secretaryImg from "$lib/images/contacts/david_s.png";
+	import accountantImg from "$lib/images/contacts/adam_b.jpg";
+	import member1Img from "$lib/images/contacts/wilmer_s.jpg";
+	import member2Img from "$lib/images/contacts/tove_h.jpg";
+	import member3Img from "$lib/images/contacts/anton_o.jpg";
+	import member4Img from "$lib/images/contacts/william_m.jpg";
+	import member5Img from "$lib/images/contacts/tom_e.jpg";
+	import maskotImg from "$lib/images/contacts/torbjorn_h.png";
 </script>
 
 <PageHead
-    title=""
-    description="LiTHe Hax is an independent student association at Linköping University focused on ethical hacking and cybersecurity."
+	title=""
+	description="LiTHe Hax is an independent student association at Linköping University focused on ethical hacking and cybersecurity."
 />
 
 <Section>
-    <h1>About us</h1>
-    <p>
-        LiTHe Hax is an independent student association at Linköping University whose
-        purpose is to promote and strengthen knowledge in ethical hacking and cybersecurity.
-        The association is intended to participate in and organize hacking competitions.
-        Anyone can be a member and participate in LiTHe Hax's activities. The association
-        was founded on March 29, 2024.
-    </p>
-    <div class="social-medias">
-        <a href="https://discord.gg/UykWT8W899">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M524.5 69.8a1.5 1.5 0 0 0 -.8-.7A485.1 485.1 0 0 0 404.1 32a1.8 1.8 0 0 0 -1.9 .9 337.5 337.5 0 0 0 -14.9 30.6 447.8 447.8 0 0 0 -134.4 0 309.5 309.5 0 0 0 -15.1-30.6 1.9 1.9 0 0 0 -1.9-.9A483.7 483.7 0 0 0 116.1 69.1a1.7 1.7 0 0 0 -.8 .7C39.1 183.7 18.2 294.7 28.4 404.4a2 2 0 0 0 .8 1.4A487.7 487.7 0 0 0 176 479.9a1.9 1.9 0 0 0 2.1-.7A348.2 348.2 0 0 0 208.1 430.4a1.9 1.9 0 0 0 -1-2.6 321.2 321.2 0 0 1 -45.9-21.9 1.9 1.9 0 0 1 -.2-3.1c3.1-2.3 6.2-4.7 9.1-7.1a1.8 1.8 0 0 1 1.9-.3c96.2 43.9 200.4 43.9 295.5 0a1.8 1.8 0 0 1 1.9 .2c2.9 2.4 6 4.9 9.1 7.2a1.9 1.9 0 0 1 -.2 3.1 301.4 301.4 0 0 1 -45.9 21.8 1.9 1.9 0 0 0 -1 2.6 391.1 391.1 0 0 0 30 48.8 1.9 1.9 0 0 0 2.1 .7A486 486 0 0 0 610.7 405.7a1.9 1.9 0 0 0 .8-1.4C623.7 277.6 590.9 167.5 524.5 69.8zM222.5 337.6c-29 0-52.8-26.6-52.8-59.2S193.1 219.1 222.5 219.1c29.7 0 53.3 26.8 52.8 59.2C275.3 311 251.9 337.6 222.5 337.6zm195.4 0c-29 0-52.8-26.6-52.8-59.2S388.4 219.1 417.9 219.1c29.7 0 53.3 26.8 52.8 59.2C470.7 311 447.5 337.6 417.9 337.6z"/></svg>
-        </a>
-        <a href="https://www.facebook.com/profile.php?id=61567434623373">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M512 256C512 114.6 397.4 0 256 0S0 114.6 0 256C0 376 82.7 476.8 194.2 504.5V334.2H141.4V256h52.8V222.3c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V172c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V256h83.6l-14.4 78.2H287V510.1C413.8 494.8 512 386.9 512 256h0z"/></svg>
-        </a>
-        <a href="https://www.instagram.com/lithehax?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw==">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z"/></svg>
-        </a>
-    </div>
+	<h1>About us</h1>
+	<p>
+		LiTHe Hax is an independent student association at Linköping University whose purpose is to
+		promote and strengthen knowledge in ethical hacking and cybersecurity. The association is
+		intended to participate in and organize hacking competitions. Anyone can be a member and
+		participate in LiTHe Hax's activities. The association was founded on March 29, 2024.
+	</p>
+	<div class="social-medias">
+		<a href="https://discord.gg/UykWT8W899">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+				<!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+				<path
+					d="M524.5 69.8a1.5 1.5 0 0 0 -.8-.7A485.1 485.1 0 0 0 404.1 32a1.8 1.8 0 0 0 -1.9 .9 337.5 337.5 0 0 0 -14.9 30.6 447.8 447.8 0 0 0 -134.4 0 309.5 309.5 0 0 0 -15.1-30.6 1.9 1.9 0 0 0 -1.9-.9A483.7 483.7 0 0 0 116.1 69.1a1.7 1.7 0 0 0 -.8 .7C39.1 183.7 18.2 294.7 28.4 404.4a2 2 0 0 0 .8 1.4A487.7 487.7 0 0 0 176 479.9a1.9 1.9 0 0 0 2.1-.7A348.2 348.2 0 0 0 208.1 430.4a1.9 1.9 0 0 0 -1-2.6 321.2 321.2 0 0 1 -45.9-21.9 1.9 1.9 0 0 1 -.2-3.1c3.1-2.3 6.2-4.7 9.1-7.1a1.8 1.8 0 0 1 1.9-.3c96.2 43.9 200.4 43.9 295.5 0a1.8 1.8 0 0 1 1.9 .2c2.9 2.4 6 4.9 9.1 7.2a1.9 1.9 0 0 1 -.2 3.1 301.4 301.4 0 0 1 -45.9 21.8 1.9 1.9 0 0 0 -1 2.6 391.1 391.1 0 0 0 30 48.8 1.9 1.9 0 0 0 2.1 .7A486 486 0 0 0 610.7 405.7a1.9 1.9 0 0 0 .8-1.4C623.7 277.6 590.9 167.5 524.5 69.8zM222.5 337.6c-29 0-52.8-26.6-52.8-59.2S193.1 219.1 222.5 219.1c29.7 0 53.3 26.8 52.8 59.2C275.3 311 251.9 337.6 222.5 337.6zm195.4 0c-29 0-52.8-26.6-52.8-59.2S388.4 219.1 417.9 219.1c29.7 0 53.3 26.8 52.8 59.2C470.7 311 447.5 337.6 417.9 337.6z"
+				/>
+			</svg>
+		</a>
+		<a href="https://www.facebook.com/profile.php?id=61567434623373">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+				<!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+				<path
+					d="M512 256C512 114.6 397.4 0 256 0S0 114.6 0 256C0 376 82.7 476.8 194.2 504.5V334.2H141.4V256h52.8V222.3c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V172c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V256h83.6l-14.4 78.2H287V510.1C413.8 494.8 512 386.9 512 256h0z"
+				/>
+			</svg>
+		</a>
+		<a
+			href="https://www.instagram.com/lithehax?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw=="
+		>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+				<!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.-->
+				<path
+					d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z"
+				/>
+			</svg>
+		</a>
+	</div>
 
-    <h2>Contact</h2>
-    <div class="contact-grid">
-        <ContactCard
-            fullName="Tyson Horvath"
-            hackerTag="tavro"
-            position="Chairman"
-            email="ordforande@lithehax.se"
-            image={chairmanImg} />
-        <ContactCard
-            fullName="David Smith"
-            hackerTag="smittydata"
-            position="Secretary"
-            email="sekreterare@lithehax.se"
-            image={secretaryImg} />
-        <ContactCard
-            fullName="Tom Englund"
-            hackerTag="naturell"
-            position="Board member"
-            email="tom.englund@lithehax.se"
-            image={member5Img} />
-        <ContactCard
-            fullName="Viktor Holta"
-            hackerTag="Parslie"
-            position="Webmaster"
-            email="webmaster@lithehax.se"
-            image={webmasterImg} />
-        <ContactCard
-            fullName="Adam Bohman"
-            hackerTag="Whiibie"
-            position="Accountant"
-            email="revisor@lithehax.se"
-            image={accountantImg} />
-        <ContactCard
-            fullName="Wilmer Segerstedt"
-            hackerTag="airless"
-            position="Logistics"
-            email="wilmer.segerstedt@lithehax.se"
-            image={member1Img} />
-        <ContactCard
-            fullName="Tove Haernfelt"
-            hackerTag="thetov"
-            position="Event manager"
-            email="tove.haernfelt@lithehax.se"
-            image={member2Img} />
-        <ContactCard
-            fullName="Anton Oom"
-            hackerTag="oomega"
-            position="Relations"
-            email="anton.oom@lithehax.se"
-            image={member3Img} />
-        <ContactCard
-            fullName="William Minidis"
-            hackerTag="windis"
-            position="Cashier"
-            email="kassor@lithehax.se"
-            image={member4Img} />
-        <ContactCard
-            fullName="Torbjörn Hackström"
-            hackerTag="hacktor"
-            position="Maskot"
-            email="maskot@lithehax.se"
-            image={maskotImg} />
-    </div>
+	<h2>Contact</h2>
+	<div class="contact-grid">
+		<ContactCard
+			fullName="Tyson Horvath"
+			hackerTag="tavro"
+			position="Chairman"
+			email="ordforande@lithehax.se"
+			image={chairmanImg}
+		/>
+		<ContactCard
+			fullName="David Smith"
+			hackerTag="smittydata"
+			position="Secretary"
+			email="sekreterare@lithehax.se"
+			image={secretaryImg}
+		/>
+		<ContactCard
+			fullName="Tom Englund"
+			hackerTag="naturell"
+			position="Board member"
+			email="tom.englund@lithehax.se"
+			image={member5Img}
+		/>
+		<ContactCard
+			fullName="Viktor Holta"
+			hackerTag="Parslie"
+			position="Webmaster"
+			email="webmaster@lithehax.se"
+			image={webmasterImg}
+		/>
+		<ContactCard
+			fullName="Adam Bohman"
+			hackerTag="Whiibie"
+			position="Accountant"
+			email="revisor@lithehax.se"
+			image={accountantImg}
+		/>
+		<ContactCard
+			fullName="Wilmer Segerstedt"
+			hackerTag="airless"
+			position="Logistics"
+			email="wilmer.segerstedt@lithehax.se"
+			image={member1Img}
+		/>
+		<ContactCard
+			fullName="Tove Haernfelt"
+			hackerTag="thetov"
+			position="Event manager"
+			email="tove.haernfelt@lithehax.se"
+			image={member2Img}
+		/>
+		<ContactCard
+			fullName="Anton Oom"
+			hackerTag="oomega"
+			position="Relations"
+			email="anton.oom@lithehax.se"
+			image={member3Img}
+		/>
+		<ContactCard
+			fullName="William Minidis"
+			hackerTag="windis"
+			position="Cashier"
+			email="kassor@lithehax.se"
+			image={member4Img}
+		/>
+		<ContactCard
+			fullName="Torbjörn Hackström"
+			hackerTag="hacktor"
+			position="Maskot"
+			email="maskot@lithehax.se"
+			image={maskotImg}
+		/>
+	</div>
 
-    <h2>Organization details</h2>
-    <p><b>Organization Number:</b> 802547-1767</p>
-    <p><b>Adress:</b> LiTHe Hax, Kårallen, Universitetet, 581 83 Linköping</p>
+	<h2>Organization details</h2>
+	<p><b>Organization Number:</b> 802547-1767</p>
+	<p><b>Adress:</b> LiTHe Hax, Kårallen, Universitetet, 581 83 Linköping</p>
 
-    <h3>Documents</h3>
-    <div class="document-list">
-        <DocumentLink link={`${base}/documents/Kallelse_Årsmöte.pdf`} />
-        <DocumentLink link={`${base}/documents/LiTHe_Hax_Stadgar_Uppdaterad.pdf`} />
-        <DocumentLink link={`${base}/documents/LiTHe_Hax_Konstituerande_Protokoll.pdf`} />
-    </div>
+	<h3>Documents</h3>
+	<div class="document-list">
+		<DocumentLink link={`${base}/documents/Kallelse_Årsmöte.pdf`} />
+		<DocumentLink link={`${base}/documents/LiTHe_Hax_Stadgar_Uppdaterad.pdf`} />
+		<DocumentLink link={`${base}/documents/LiTHe_Hax_Konstituerande_Protokoll.pdf`} />
+	</div>
 </Section>
 
 <style>
-    /* Mobile styling */
-    @media screen and (min-width: 0px) {
-        .contact-grid {
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
-        }
-    }
+	/* Mobile styling */
+	@media screen and (min-width: 0px) {
+		.contact-grid {
+			display: flex;
+			flex-direction: column;
+			gap: 1rem;
+		}
+	}
 
-    /* Desktop styling */
-    @media screen and (min-width: 768px) {
-        .contact-grid {
-            display: grid;
-            gap: 1rem;
-            grid-template-columns: repeat(auto-fill, minmax(26rem, 1fr));
-        }
-    }
+	/* Desktop styling */
+	@media screen and (min-width: 768px) {
+		.contact-grid {
+			display: grid;
+			gap: 1rem;
+			grid-template-columns: repeat(auto-fill, minmax(26rem, 1fr));
+		}
+	}
 
-    .document-list {
-        display: flex;
-        flex-direction: column;
-        gap: 0.2rem;
-    }
+	.document-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
 
-    .social-medias {
-        display: flex;
-        flex-direction: row;
-        gap: 0.5rem;
-    }
+	.social-medias {
+		display: flex;
+		flex-direction: row;
+		gap: 0.5rem;
+	}
 
-    .social-medias svg {
-        height: 2rem;
-    }
+	.social-medias svg {
+		height: 2rem;
+	}
 </style>

--- a/src/routes/christmas-2024/+page.svelte
+++ b/src/routes/christmas-2024/+page.svelte
@@ -1,164 +1,163 @@
 <script lang="ts">
-    import Section from "$lib/components/Section.svelte";
-    import PageHead from "$lib/components/PageHead.svelte";
+	import Section from "$lib/components/Section.svelte";
+	import PageHead from "$lib/components/PageHead.svelte";
 
-    type LeaderboardRow = [string, string];
-    let leaderboardRows = $state<LeaderboardRow[] | undefined>(undefined);
-    let hasError = $state(false);
+	type LeaderboardRow = [string, string];
+	let leaderboardRows = $state<LeaderboardRow[] | undefined>(undefined);
+	let hasError = $state(false);
 
-    const SHEET_URL = 'https://docs.google.com/spreadsheets/d/14h0sFurutGcILR8XnIPeVq3mBKpCXTCFUmIeAFZCvQg/edit?usp=sharing';
+	const SHEET_URL =
+		"https://docs.google.com/spreadsheets/d/14h0sFurutGcILR8XnIPeVq3mBKpCXTCFUmIeAFZCvQg/edit?usp=sharing";
 
-    // @ts-ignore
-    async function scrapeGoogleSheet(url) {
-        try {
-            const response = await fetch(url);
-            if (!response.ok) {
-                throw new Error(`Failed to fetch the sheet: ${response.statusText}`);
-            }
-            const html = await response.text();
+	async function scrapeGoogleSheet(url: string) {
+		try {
+			const response = await fetch(url);
+			if (!response.ok) {
+				throw new Error(`Failed to fetch the sheet: ${response.statusText}`);
+			}
+			const html = await response.text();
 
-            const parser = new DOMParser();
-            const doc = parser.parseFromString(html, 'text/html');
+			const parser = new DOMParser();
+			const doc = parser.parseFromString(html, "text/html");
 
-            const table = doc.querySelector('table');
-            if (!table) {
-                throw new Error('No table found in the sheet.');
-            }
+			const table = doc.querySelector("table");
+			if (!table) {
+				throw new Error("No table found in the sheet.");
+			}
 
-            const rows = Array.from(table.querySelectorAll('tr'));
-            const data = rows.map((row) =>
-                Array.from(row.querySelectorAll('td')).map((cell) => cell.innerText.trim())
-            );
+			const rows = Array.from(table.querySelectorAll("tr"));
+			const data = rows.map((row) =>
+				Array.from(row.querySelectorAll("td")).map((cell) => cell.innerText.trim()),
+			);
 
-            let result: LeaderboardRow[] = [];
-            for (let i = 2; i < data.length; i++) {
-                const [timestamp, nickname] = data[i];
-                if (nickname && timestamp) {
-                    result.push([nickname, timestamp]);
-                }
-            }
+			let result: LeaderboardRow[] = [];
+			for (let i = 2; i < data.length; i++) {
+				const [timestamp, nickname] = data[i];
+				if (nickname && timestamp) {
+					result.push([nickname, timestamp]);
+				}
+			}
 
-            return result;
-        } catch (error) {
-            console.error('Error:', error);
-            hasError = true;
-            return null;
-        }
-    }
+			return result;
+		} catch (error) {
+			console.error("Error:", error);
+			hasError = true;
+			return null;
+		}
+	}
 
-    $effect(() => {
-        scrapeGoogleSheet(SHEET_URL).then((json) => {
-            if (json === null)
-                leaderboardRows = undefined;
-            else
-                leaderboardRows = json;
-        });
-    });
+	$effect(() => {
+		scrapeGoogleSheet(SHEET_URL).then((json) => {
+			if (json === null) leaderboardRows = undefined;
+			else leaderboardRows = json;
+		});
+	});
 </script>
 
 <PageHead
-    title="Christmas 2024"
-    description="Leaderboard for the LiTHe Hax Christmas CTF 2024 competition."
+	title="Christmas 2024"
+	description="Leaderboard for the LiTHe Hax Christmas CTF 2024 competition."
 />
 
 <Section isThin>
-    <h1>Christmas CTF 2024 Leaderboard</h1>
-    {#if hasError}
-        <p>Could not load leaderboard, try again later.</p>
-    {:else if leaderboardRows === undefined}
-        <p>Loading leaderboard...</p>
-    {:else}
-        <table>
-            <thead>
-                <tr>
-                    <td>#</td>
-                    <td>Name</td>
-                    <td>Time Cleared</td>
-                </tr>
-            </thead>
-            <tbody>
-                {#each leaderboardRows as row, i}
-                    <tr>
-                        <td>{i + 1}</td>
-                        <td>{row[0]}</td>
-                        <td>{row[1]}</td>
-                    </tr>
-                {/each}
-            </tbody>
-        </table>
-    {/if}
+	<h1>Christmas CTF 2024 Leaderboard</h1>
+	{#if hasError}
+		<p>Could not load leaderboard, try again later.</p>
+	{:else if leaderboardRows === undefined}
+		<p>Loading leaderboard...</p>
+	{:else}
+		<table>
+			<thead>
+				<tr>
+					<td>#</td>
+					<td>Name</td>
+					<td>Time Cleared</td>
+				</tr>
+			</thead>
+			<tbody>
+				{#each leaderboardRows as row, i (i)}
+					<tr>
+						<td>{i + 1}</td>
+						<td>{row[0]}</td>
+						<td>{row[1]}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	{/if}
 </Section>
 
 <style>
-    table {
-        width: 100%;
-        border-spacing: 0;
-    }
+	table {
+		width: 100%;
+		border-spacing: 0;
+	}
 
-    thead, tbody {
-        box-shadow: 0 2px 4px 0 #00000044;
-    }
+	thead,
+	tbody {
+		box-shadow: 0 2px 4px 0 #00000044;
+	}
 
-    td {
-        padding: 0.25rem;
-        text-align: center;
-    }
+	td {
+		padding: 0.25rem;
+		text-align: center;
+	}
 
-    thead td {
-        border: 1px solid #333333;
-        background-color: #232323;
-    }
+	thead td {
+		border: 1px solid #333333;
+		background-color: #232323;
+	}
 
-    thead td:first-child {
-        border-top-left-radius: 0.25rem;
-        border-bottom-left-radius: 0.25rem;
-    }
+	thead td:first-child {
+		border-top-left-radius: 0.25rem;
+		border-bottom-left-radius: 0.25rem;
+	}
 
-    thead td:last-child {
-        border-top-right-radius: 0.25rem;
-        border-bottom-right-radius: 0.25rem;
-    }
+	thead td:last-child {
+		border-top-right-radius: 0.25rem;
+		border-bottom-right-radius: 0.25rem;
+	}
 
-    tbody:before {
-        content: "-";
-        display: block;
-        line-height: 0.25rem;
-        color: transparent;
-    }
+	tbody:before {
+		content: "-";
+		display: block;
+		line-height: 0.25rem;
+		color: transparent;
+	}
 
-    tbody td {
-        border: 1px solid #444444;
-    }
+	tbody td {
+		border: 1px solid #444444;
+	}
 
-    tbody tr:not(:first-child) td {
-        border-top: none;
-    }
+	tbody tr:not(:first-child) td {
+		border-top: none;
+	}
 
-    tbody tr:nth-child(odd) td {
-        background-color: #2a2a2a;
-    }
+	tbody tr:nth-child(odd) td {
+		background-color: #2a2a2a;
+	}
 
-    tbody tr:nth-child(even) td {
-        background-color: #333333;
-    }
+	tbody tr:nth-child(even) td {
+		background-color: #333333;
+	}
 
-    tbody tr:first-child td:first-child {
-        border-top-left-radius: 0.25rem;
-    }
+	tbody tr:first-child td:first-child {
+		border-top-left-radius: 0.25rem;
+	}
 
-    tbody tr:first-child td:last-child {
-        border-top-right-radius: 0.25rem;
-    }
+	tbody tr:first-child td:last-child {
+		border-top-right-radius: 0.25rem;
+	}
 
-    tbody tr:last-child td:first-child {
-        border-bottom-left-radius: 0.25rem;
-    }
+	tbody tr:last-child td:first-child {
+		border-bottom-left-radius: 0.25rem;
+	}
 
-    tbody tr:last-child td:last-child {
-        border-bottom-right-radius: 0.25rem;
-    }
+	tbody tr:last-child td:last-child {
+		border-bottom-right-radius: 0.25rem;
+	}
 
-    td:not(:last-child) {
-        border-right: none;
-    }
+	td:not(:last-child) {
+		border-right: none;
+	}
 </style>

--- a/src/routes/ctf/+page.svelte
+++ b/src/routes/ctf/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-    import { base } from "$app/paths";
-    $effect(() => {
-        window.location.href = `${base}/events`;
-    });
+	import { base } from "$app/paths";
+	$effect(() => {
+		window.location.href = `${base}/events`;
+	});
 </script>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -1,269 +1,256 @@
 <script lang="ts">
-  import Section from "$lib/components/Section.svelte";
-  import cyberRoom from "$lib/images/ctf/cyber-room.jpg";
-  import sickLogo from "$lib/images/ctf/sick-logo.png";
-  import sectraLogo from "$lib/images/ctf/sectra-logo.png";
-  import sylogLogo from "$lib/images/ctf/sylog-logo.png";
-  import DocumentLink from "$lib/components/DocumentLink.svelte";
-  import { base } from "$app/paths";
-  import studenthuset from "$lib/images/workshop/studenthuset.jpg";
-  import foobar from "$lib/images/foocafe/foobar.jpg";
-  import gototenLogo from "$lib/images/foocafe/goto10-logo.png";
-  import foocafeLogo from "$lib/images/foocafe/foocafe-logo.svg";
-  import acas from "$lib/images/annual-meeting/acas.png";
-  import PageHead from "$lib/components/PageHead.svelte";
+	import Section from "$lib/components/Section.svelte";
+	import cyberRoom from "$lib/images/ctf/cyber-room.jpg";
+	import sickLogo from "$lib/images/ctf/sick-logo.png";
+	import sectraLogo from "$lib/images/ctf/sectra-logo.png";
+	import sylogLogo from "$lib/images/ctf/sylog-logo.png";
+	import DocumentLink from "$lib/components/DocumentLink.svelte";
+	import { base } from "$app/paths";
+	import studenthuset from "$lib/images/workshop/studenthuset.jpg";
+	import foobar from "$lib/images/foocafe/foobar.jpg";
+	import gototenLogo from "$lib/images/foocafe/goto10-logo.png";
+	import foocafeLogo from "$lib/images/foocafe/foocafe-logo.svg";
+	import acas from "$lib/images/annual-meeting/acas.png";
+	import PageHead from "$lib/components/PageHead.svelte";
 </script>
 
 <PageHead
-  title="Events"
-  description="LiTHe Hax events including Annual Meeting, CTF competition, workshops, and networking opportunities at Linköping University, GOTO10, Foocafe and more"
+	title="Events"
+	description="LiTHe Hax events including Annual Meeting, CTF competition, workshops, and networking opportunities at Linköping University, GOTO10, Foocafe and more"
 />
 
 <h2 class="section-header">Upcoming Events</h2>
 
 <Section isThin>
-  <p>There are currently no upcoming events...</p>
+	<p>There are currently no upcoming events...</p>
 </Section>
 
 <h2 class="section-header">Previous Events</h2>
 
 <Section isThin>
-  <div class="past-event">
-    <h1>Annual Meeting</h1>
-    <img src={acas} alt="ACAS at Linköping University" />
-    <p>
-      We will be holding our annual meeting soon, which you're very welcome to
-      attend! During the meeting we'll talk about the last year of LiTHe Hax and
-      we'll be voting on the next year of LiTHe Hax. One thing that'll be voted on
-      is who will be included in the next board, so this is your chance to join
-      and affect the future of LiTHe Hax.
-    </p>
-    <p>Coffee and fika will be provided to everyone who attend the meeting.</p>
-    <p><strong>Date & Time:</strong> 28 May 2025, 17:15</p>
-    <p>
-      <strong>Location:</strong>
-      <a
-        href="https://use.mazemap.com/?utm_medium=longurl#v=1&config=liu&campusid=742&zlevel=2&center=15.576810,58.402255&zoom=18&sharepoitype=poi&sharepoi=1000927810"
-      >
-        ACAS (Linköping University, Sweden)
-      </a>
-    </p>
-    <p>
-      <strong>Agenda:</strong>
-      <DocumentLink link={`${base}/documents/Kallelse_Årsmöte.pdf`} />
-    </p>
+	<div class="past-event">
+		<h1>Annual Meeting</h1>
+		<img src={acas} alt="ACAS at Linköping University" />
+		<p>
+			We will be holding our annual meeting soon, which you're very welcome to attend! During the
+			meeting we'll talk about the last year of LiTHe Hax and we'll be voting on the next year of
+			LiTHe Hax. One thing that'll be voted on is who will be included in the next board, so this is
+			your chance to join and affect the future of LiTHe Hax.
+		</p>
+		<p>Coffee and fika will be provided to everyone who attend the meeting.</p>
+		<p><strong>Date & Time:</strong> 28 May 2025, 17:15</p>
+		<p>
+			<strong>Location:</strong>
+			<a
+				href="https://use.mazemap.com/?utm_medium=longurl#v=1&config=liu&campusid=742&zlevel=2&center=15.576810,58.402255&zoom=18&sharepoitype=poi&sharepoi=1000927810"
+			>
+				ACAS (Linköping University, Sweden)
+			</a>
+		</p>
+		<p>
+			<strong>Agenda:</strong>
+			<DocumentLink link={`${base}/documents/Kallelse_Årsmöte.pdf`} />
+		</p>
 
-    <h3>Candidacy</h3>
-    <p>
-      Anyone can can run for the positions brought up during the meeting. You can
-      oppose any of the current nominees, which means that you can nominate
-      yourself or someone else for that position (without having been previously
-      nominated). You can also submit an opposition by sending a mail to <a
-        href="mailto:ordforande@lithehax.se">ordforande@lithehax.se</a
-      >, where you explain which position you're interested in and why you are a
-      suitable candidate.
-    </p>
-    <p>
-      If you are running for a position in the board you will have to present
-      yourself during the meeting and answer any potential questions. Below are
-      some suggestions of what you may want to bring up when presenting yourself:
-    </p>
-    <ul>
-      <li>Who you are</li>
-      <li>Why you are running for the position</li>
-      <li>Past experiences that may be of relevance</li>
-    </ul>
-    <p>
-      <strong>Current nominees:</strong>
-      <DocumentLink
-        link={`${base}/documents/2024-2025/events/annual_meeting/nominations.pdf`}
-      />
-    </p>
+		<h3>Candidacy</h3>
+		<p>
+			Anyone can can run for the positions brought up during the meeting. You can oppose any of the
+			current nominees, which means that you can nominate yourself or someone else for that position
+			(without having been previously nominated). You can also submit an opposition by sending a
+			mail to <a href="mailto:ordforande@lithehax.se">ordforande@lithehax.se</a>, where you explain
+			which position you're interested in and why you are a suitable candidate.
+		</p>
+		<p>
+			If you are running for a position in the board you will have to present yourself during the
+			meeting and answer any potential questions. Below are some suggestions of what you may want to
+			bring up when presenting yourself:
+		</p>
+		<ul>
+			<li>Who you are</li>
+			<li>Why you are running for the position</li>
+			<li>Past experiences that may be of relevance</li>
+		</ul>
+		<p>
+			<strong>Current nominees:</strong>
+			<DocumentLink link={`${base}/documents/2024-2025/events/annual_meeting/nominations.pdf`} />
+		</p>
 
-    <h3>Motions</h3>
+		<h3>Motions</h3>
 
-    <p>
-      Anyone can send in motions. The easiest way to do this is by mailing the
-      motion to <a href="mailto:ordforande@lithehax.se">ordforande@lithehax.se</a
-      >. Motions must be sent in writing to the board no later than seven days
-      before the meeting (21 May 2025).
-    </p>
-    <p>
-      <strong>Current motions and propositions:</strong>
-      <DocumentLink
-        link={`${base}/documents/2024-2025/events/annual_meeting/motions_and_propositions.pdf`}
-      />
-    </p>
-  </div>
+		<p>
+			Anyone can send in motions. The easiest way to do this is by mailing the motion to
+			<a href="mailto:ordforande@lithehax.se">ordforande@lithehax.se</a>. Motions must be sent in
+			writing to the board no later than seven days before the meeting (21 May 2025).
+		</p>
+		<p>
+			<strong>Current motions and propositions:</strong>
+			<DocumentLink
+				link={`${base}/documents/2024-2025/events/annual_meeting/motions_and_propositions.pdf`}
+			/>
+		</p>
+	</div>
 </Section>
 
 <Section isThin>
-  <div class="past-event">
-    <h1>Foo Bar at Foo Café</h1>
+	<div class="past-event">
+		<h1>Foo Bar at Foo Café</h1>
 
-    <img src={foobar} alt="Foo Bar at Foo Café" />
-    <p>
-      Foo Café and LiTHe Hax recently teamed up for a cybersecurity evening
-      focused on Capture the Flag challenges. The event featured a brief
-      introduction, a problem-solving lecture, and a chance to network over food
-      and drinks with others passionate about cybersecurity.
-    </p>
-    <p><strong>Date & Time:</strong> 24 Apr 2025, 17:00-20:00</p>
-    <p>
-      <strong>Location:</strong>
-      <a href="https://maps.app.goo.gl/LNrr7CWQWwaH3deJ9">
-        Goto 10 Linköping (Teknikringen 7, 583 30 Linköping)
-      </a>
-    </p>
-    <p>
-      <strong>Presentation:</strong>
-      <DocumentLink link={`${base}/documents/GOTO10 Presentation.pptx`} />
-    </p>
+		<img src={foobar} alt="Foo Bar at Foo Café" />
+		<p>
+			Foo Café and LiTHe Hax recently teamed up for a cybersecurity evening focused on Capture the
+			Flag challenges. The event featured a brief introduction, a problem-solving lecture, and a
+			chance to network over food and drinks with others passionate about cybersecurity.
+		</p>
+		<p><strong>Date & Time:</strong> 24 Apr 2025, 17:00-20:00</p>
+		<p>
+			<strong>Location:</strong>
+			<a href="https://maps.app.goo.gl/LNrr7CWQWwaH3deJ9">
+				Goto 10 Linköping (Teknikringen 7, 583 30 Linköping)
+			</a>
+		</p>
+		<p>
+			<strong>Presentation:</strong>
+			<DocumentLink link={`${base}/documents/GOTO10 Presentation.pptx`} />
+		</p>
 
-    <hr />
-    <div class="sponsor-logos">
-      <img src={gototenLogo} alt="Goto 10 logo" />
-      <img src={foocafeLogo} alt="Goto 10 logo" />
-    </div>
-  </div>
+		<hr />
+		<div class="sponsor-logos">
+			<img src={gototenLogo} alt="Goto 10 logo" />
+			<img src={foocafeLogo} alt="Goto 10 logo" />
+		</div>
+	</div>
 </Section>
 
 <Section isThin>
-  <div class="past-event">
-    <h1>LiU CTF</h1>
+	<div class="past-event">
+		<h1>LiU CTF</h1>
 
-    <img src={cyberRoom} alt="Cybersecurity Room" />
-    <p>
-      The LiTHe Hax LiU CTF was an exciting Capture the Flag competition held on
-      March 8. We hosted this event to promote cybersecurity awareness within
-      the student community, combining both relevance and fun.
-    </p>
-    <p>
-      A total of 18 teams competed, each consisting of 2–5 participants. Free
-      food was provided to all participants.
-    </p>
-    <p><strong>Date & Time:</strong> 8 Mar 2025, 17:15-23:00</p>
-    <p>
-      <strong>Location:</strong>
-      <a
-        href="https://use.mazemap.com/?utm_medium=longurl#v=1&config=liu&campusid=742&zlevel=2&center=15.576432,58.398370&zoom=18&sharepoitype=poi&sharepoi=1002771474"
-      >
-        Brandväggen, Bakdörren and ISYtan (Linköping University, Sweden)
-      </a>
-    </p>
-    <p>
-      <strong>CTF Platform:</strong>
-      <a href="https://ctf.lithehax.se"> ctf.lithehax.se </a>
-    </p>
-    <p>
-      <strong>CTF rules:</strong>
-      <DocumentLink class="workshop" link={`${base}/documents/rules.pdf`} />
-    </p>
+		<img src={cyberRoom} alt="Cybersecurity Room" />
+		<p>
+			The LiTHe Hax LiU CTF was an exciting Capture the Flag competition held on March 8. We hosted
+			this event to promote cybersecurity awareness within the student community, combining both
+			relevance and fun.
+		</p>
+		<p>
+			A total of 18 teams competed, each consisting of 2–5 participants. Free food was provided to
+			all participants.
+		</p>
+		<p><strong>Date & Time:</strong> 8 Mar 2025, 17:15-23:00</p>
+		<p>
+			<strong>Location:</strong>
+			<a
+				href="https://use.mazemap.com/?utm_medium=longurl#v=1&config=liu&campusid=742&zlevel=2&center=15.576432,58.398370&zoom=18&sharepoitype=poi&sharepoi=1002771474"
+			>
+				Brandväggen, Bakdörren and ISYtan (Linköping University, Sweden)
+			</a>
+		</p>
+		<p>
+			<strong>CTF Platform:</strong>
+			<a href="https://ctf.lithehax.se"> ctf.lithehax.se </a>
+		</p>
+		<p>
+			<strong>CTF rules:</strong>
+			<DocumentLink link={`${base}/documents/rules.pdf`} />
+		</p>
 
-    <hr />
-    <div class="sponsor-logos">
-      <img src={sickLogo} alt="sick logo" />
-      <img src={sectraLogo} alt="sectra logo" />
-      <img src={sylogLogo} alt="sylog logo" />
-    </div>
-  </div>
+		<hr />
+		<div class="sponsor-logos">
+			<img src={sickLogo} alt="sick logo" />
+			<img src={sectraLogo} alt="sectra logo" />
+			<img src={sylogLogo} alt="sylog logo" />
+		</div>
+	</div>
 </Section>
 
 <Section isThin>
-  <div class="past-event">
-    <h1>Workshop</h1>
-    <img src={studenthuset} alt="Studenthuset" />
-    <p>
-      We held a workshop in preparation for our CTF. During the workshop, we
-      explained and showcased example challenges that resembled the actual CTF
-      challenges.
-    </p>
-    <p>
-      There were 80 available seats, and those who registered were provided free
-      food, sponsored by the companies below.
-    </p>
-    <p><strong>Date & Time:</strong> 27 Feb 2025, 17:15-20:00</p>
-    <p>
-      <strong>Location:</strong>
-      <a
-        href="https://use.mazemap.com/#v=1&config=liu&campusid=742&zlevel=6&center=15.577904,58.397057&zoom=18.9&sharepoitype=poi&sharepoi=1000927265"
-      >
-        SH62 and SH63 (Linköping University, Sweden)
-      </a>
-    </p>
-    <p>
-      <strong>Workshop tasks:</strong>
-      <DocumentLink class="workshop" link={`${base}/documents/workshop.zip`} />
-    </p>
-    <p>
-      <strong>Workshop presentation:</strong>
-      <DocumentLink
-        class="workshop"
-        link={`${base}/documents/Workshop Presentation.pptx`}
-      />
-    </p>
+	<div class="past-event">
+		<h1>Workshop</h1>
+		<img src={studenthuset} alt="Studenthuset" />
+		<p>
+			We held a workshop in preparation for our CTF. During the workshop, we explained and showcased
+			example challenges that resembled the actual CTF challenges.
+		</p>
+		<p>
+			There were 80 available seats, and those who registered were provided free food, sponsored by
+			the companies below.
+		</p>
+		<p><strong>Date & Time:</strong> 27 Feb 2025, 17:15-20:00</p>
+		<p>
+			<strong>Location:</strong>
+			<a
+				href="https://use.mazemap.com/#v=1&config=liu&campusid=742&zlevel=6&center=15.577904,58.397057&zoom=18.9&sharepoitype=poi&sharepoi=1000927265"
+			>
+				SH62 and SH63 (Linköping University, Sweden)
+			</a>
+		</p>
+		<p>
+			<strong>Workshop tasks:</strong>
+			<DocumentLink link={`${base}/documents/workshop.zip`} />
+		</p>
+		<p>
+			<strong>Workshop presentation:</strong>
+			<DocumentLink link={`${base}/documents/Workshop Presentation.pptx`} />
+		</p>
 
-    <hr />
-    <div class="sponsor-logos">
-      <img src={sickLogo} alt="sick logo" />
-      <img src={sectraLogo} alt="sectra logo" />
-    </div>
-  </div>
+		<hr />
+		<div class="sponsor-logos">
+			<img src={sickLogo} alt="sick logo" />
+			<img src={sectraLogo} alt="sectra logo" />
+		</div>
+	</div>
 </Section>
 
 <style>
-  img {
-    max-width: 100%;
-    height: auto;
-  }
+	img {
+		max-width: 100%;
+		height: auto;
+	}
 
-  .sponsor-logos {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: center;
-    margin: 1rem 0;
-  }
+	.sponsor-logos {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap;
+		gap: 1rem;
+		justify-content: center;
+		margin: 1rem 0;
+	}
 
-  .sponsor-logos img {
-    height: 2rem;
-  }
+	.sponsor-logos img {
+		height: 2rem;
+	}
 
-  .past-event {
-    opacity: 0.5;
-  }
+	.past-event {
+		opacity: 0.5;
+	}
 
-  .past-event img {
-    filter: saturate(50%);
-  }
+	.past-event img {
+		filter: saturate(50%);
+	}
 
-  .past-event h1 {
-    margin-top: 0;
-    color: var(--header-fg);
-  }
+	.past-event h1 {
+		margin-top: 0;
+		color: var(--header-fg);
+	}
 
-  /* Mobile styling */
-  @media screen and (min-width: 0px) {
-    .section-header {
-      font-size: 1.75rem;
-      color: var(--heading-fg);
-      margin: 1rem 1.25rem;
-      max-width: min(36rem, calc(100% - 6rem));
-    }
-  }
+	/* Mobile styling */
+	@media screen and (min-width: 0px) {
+		.section-header {
+			font-size: 1.75rem;
+			color: var(--heading-fg);
+			margin: 1rem 1.25rem;
+			max-width: min(36rem, calc(100% - 6rem));
+		}
+	}
 
-  /* Desktop styling */
-  @media screen and (min-width: 768px) {
-    .section-header {
-      font-size: 1.75rem;
-      color: var(--heading-fg);
-      margin-top: 3rem;
-      margin-bottom: -2rem;
-      margin-left: calc(
-        50% - min(18rem, 50% - 3rem) - 1.25rem
-      ); /* This feels very hacky */
-      max-width: min(36rem, calc(100% - 6rem));
-    }
-  }
+	/* Desktop styling */
+	@media screen and (min-width: 768px) {
+		.section-header {
+			font-size: 1.75rem;
+			color: var(--heading-fg);
+			margin-top: 3rem;
+			margin-bottom: -2rem;
+			margin-left: calc(50% - min(18rem, 50% - 3rem) - 1.25rem); /* This feels very hacky */
+			max-width: min(36rem, calc(100% - 6rem));
+		}
+	}
 </style>

--- a/src/routes/new-member/+page.svelte
+++ b/src/routes/new-member/+page.svelte
@@ -1,122 +1,134 @@
 <script lang="ts">
-    import FormSubmit from "$lib/components/FormSubmit.svelte";
-    import FormField from "$lib/components/FormField.svelte";
-    import Section from "$lib/components/Section.svelte";
-    import PageHead from "$lib/components/PageHead.svelte";
-    import { createMember } from "$lib/api/member";
-    import type { AxiosError, AxiosResponse } from "axios";
+	import FormSubmit from "$lib/components/FormSubmit.svelte";
+	import FormField from "$lib/components/FormField.svelte";
+	import Section from "$lib/components/Section.svelte";
+	import PageHead from "$lib/components/PageHead.svelte";
+	import { createMember } from "$lib/api/member";
+	import type { AxiosError } from "axios";
 
-    let isSubmitting = $state(false);
-    let isSuccessful = $state(false);
-    let errorMessage = $state("");
+	let isSubmitting = $state(false);
+	let isSuccessful = $state(false);
+	let errorMessage = $state("");
 
-    let firstNameError = $state<string | undefined>(undefined);
-    let lastNameError = $state<string | undefined>(undefined);
-    let emailError = $state<string | undefined>(undefined);
-    let membershipTypeError = $state<string | undefined>(undefined);
+	let firstNameError = $state<string | undefined>(undefined);
+	let lastNameError = $state<string | undefined>(undefined);
+	let emailError = $state<string | undefined>(undefined);
+	let membershipTypeError = $state<string | undefined>(undefined);
 
-    function requestMembership(e: SubmitEvent) {
-        e.preventDefault();
-        const formData = new FormData(e.target as HTMLFormElement);
-        const firstName = formData.get("firstName")!.toString();
-        const lastName = formData.get("lastName")!.toString();
-        const email = formData.get("email")!.toString();
-        const membershipType = formData.get("membershipType")!.toString();
-        const isStudent = membershipType === "student";
+	function requestMembership(e: SubmitEvent) {
+		e.preventDefault();
+		const formData = new FormData(e.target as HTMLFormElement);
+		const firstName = formData.get("firstName")!.toString();
+		const lastName = formData.get("lastName")!.toString();
+		const email = formData.get("email")!.toString();
+		const membershipType = formData.get("membershipType")!.toString();
+		const isStudent = membershipType === "student";
 
-        isSubmitting = true;
-        isSuccessful = false;
-        errorMessage = "";
-        firstNameError = undefined;
-        lastNameError = undefined;
-        emailError = undefined;
-        membershipTypeError = undefined;
+		isSubmitting = true;
+		isSuccessful = false;
+		errorMessage = "";
+		firstNameError = undefined;
+		lastNameError = undefined;
+		emailError = undefined;
+		membershipTypeError = undefined;
 
-        createMember(firstName, lastName, email, isStudent).then((res: AxiosResponse) => {
-            isSuccessful = true;
-        }).catch((err: AxiosError) => {
-            if (err.response !== undefined) {
-                errorMessage = err.response.status.toString() + " " + err.response.statusText;
-                let data = err.response.data as {};
-                if ('first_name' in data) {
-                    let mainError = (data.first_name as string[])[0];
-                    firstNameError = mainError;
-                }
-                if ('last_name' in data) {
-                    let mainError = (data.last_name as string[])[0];
-                    lastNameError = mainError;
-                }
-                if ('email' in data) {
-                    let mainError = (data.email as string[])[0];
-                    emailError = mainError;
-                }
-                if ('is_student' in data) {
-                    let mainError = (data.is_student as string[])[0];
-                    membershipTypeError = mainError;
-                }
-            } else {
-                errorMessage = "The server didn't respond...";
-            }
-        }).finally(() => {
-            isSubmitting = false;
-        });
-    }
+		createMember(firstName, lastName, email, isStudent)
+			.then(() => {
+				isSuccessful = true;
+			})
+			.catch((err: AxiosError) => {
+				if (err.response !== undefined) {
+					errorMessage = err.response.status.toString() + " " + err.response.statusText;
+					let data = err.response.data as object;
+					if ("first_name" in data) {
+						let mainError = (data.first_name as string[])[0];
+						firstNameError = mainError;
+					}
+					if ("last_name" in data) {
+						let mainError = (data.last_name as string[])[0];
+						lastNameError = mainError;
+					}
+					if ("email" in data) {
+						let mainError = (data.email as string[])[0];
+						emailError = mainError;
+					}
+					if ("is_student" in data) {
+						let mainError = (data.is_student as string[])[0];
+						membershipTypeError = mainError;
+					}
+				} else {
+					errorMessage = "The server didn't respond...";
+				}
+			})
+			.finally(() => {
+				isSubmitting = false;
+			});
+	}
 </script>
 
-<PageHead title="Member" description="Join LiTHe Hax and gain access to exclusive events, resources, and updates - become a member today!" />
+<PageHead
+	title="Member"
+	description="Join LiTHe Hax and gain access to exclusive events, resources, and updates - become a member today!"
+/>
 
 <Section isThin>
-    <h1>Become a member</h1>
-    <p>
-        Join LiTHe Hax and become a member! As a member, you'll gain access to exclusive
-        events, resources, and updates about our organization's activities. Once your
-        membership is approved by our board, we will contact you with further details.
-    </p>
+	<h1>Become a member</h1>
+	<p>
+		Join LiTHe Hax and become a member! As a member, you'll gain access to exclusive events,
+		resources, and updates about our organization's activities. Once your membership is approved by
+		our board, we will contact you with further details.
+	</p>
 
-    <form onsubmit={requestMembership}>
-        <FormField name="firstName" label="First name" type="text" required error={firstNameError} />
-        <FormField name="lastName" label="Last name" type="text" required error={lastNameError} />
-        <FormField name="email" label="Email" type="email" required error={emailError} />
-        <FormField name="membershipType" label="Membership type" type="select" required error={membershipTypeError}>
-            <option value="">--Please select a membership type--</option>
-            <option value="student">Student</option>
-            <option value="non-student">Non-student</option>
-        </FormField>
-        <FormSubmit disabled={isSubmitting}>Apply for membership</FormSubmit>
-    </form>
+	<form onsubmit={requestMembership}>
+		<FormField name="firstName" label="First name" type="text" required error={firstNameError} />
+		<FormField name="lastName" label="Last name" type="text" required error={lastNameError} />
+		<FormField name="email" label="Email" type="email" required error={emailError} />
+		<FormField
+			name="membershipType"
+			label="Membership type"
+			type="select"
+			required
+			error={membershipTypeError}
+		>
+			<option value="">--Please select a membership type--</option>
+			<option value="student">Student</option>
+			<option value="non-student">Non-student</option>
+		</FormField>
+		<FormSubmit disabled={isSubmitting}>Apply for membership</FormSubmit>
+	</form>
 
-    {#if isSuccessful}
-        <p class="success-msg">Successfully applied for a membership!</p>
-    {:else if errorMessage !== ""}
-        <p class="error-msg">{errorMessage}</p>
-    {/if}
+	{#if isSuccessful}
+		<p class="success-msg">Successfully applied for a membership!</p>
+	{:else if errorMessage !== ""}
+		<p class="error-msg">{errorMessage}</p>
+	{/if}
 </Section>
 
 <style>
-    form {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        grid-template-rows: 1fr 1fr 1fr 1fr;
-        gap: 0.8rem;
-    }
+	form {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-template-rows: 1fr 1fr 1fr 1fr;
+		gap: 0.8rem;
+	}
 
-    form > :global(:nth-child(3)),
-    form > :global(:nth-child(4)) {
-        grid-column: 1 / span 2;
-    }
+	form > :global(:nth-child(3)),
+	form > :global(:nth-child(4)) {
+		grid-column: 1 / span 2;
+	}
 
-    form > :global(:nth-child(5)) {
-        grid-column: 1 / span 2;
-        align-self: flex-end;
-    }
+	form > :global(:nth-child(5)) {
+		grid-column: 1 / span 2;
+		align-self: flex-end;
+	}
 
-    .success-msg {
-        color: var(--success-color);
-        text-align: center;
-    }
+	.success-msg {
+		color: var(--success-color);
+		text-align: center;
+	}
 
-    .error-msg {
-        color: var(--error-color);
-        text-align: center;
-    }
+	.error-msg {
+		color: var(--error-color);
+		text-align: center;
+	}
 </style>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,5 @@
-import adapter from '@sveltejs/adapter-static';
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+import adapter from "@sveltejs/adapter-static";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -12,8 +12,8 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
 		adapter: adapter(),
-		paths: { base: process.argv.includes('dev') ? '' : process.env.BASE_PATH },
-	}
+		paths: { base: process.argv.includes("dev") ? "" : process.env.BASE_PATH },
+	},
 };
 
 export default config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
-import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
 
 export default defineConfig({
 	plugins: [sveltekit()],


### PR DESCRIPTION
This PR configures the formatter (Prettier) and linter (ESLint), as well as runs the formatter and fixes linting errors.

Regarding ESLint I've chosen to keep most of the recommended settings as they are. Only three rules have been changed:

- "[no-unneeded-ternary](https://eslint.org/docs/latest/rules/no-unneeded-ternary)" has been enabled, since it's unnecessary and serves as a good reminder to take a break.
- "[prefer-spread](https://eslint.org/docs/latest/rules/prefer-spread)" has been enabled, since `func(...args)` seems more readable than `func.apply(null, args)`.
- "[svelte/no-target-blank](https://sveltejs.github.io/eslint-plugin-svelte/rules/no-target-blank/)" has been enabled, since it helps us avoid triggering a [security vulnerability](https://mathiasbynens.github.io/rel-noopener/) in older browsers.

If you have any suggestions on settings to enable or disable, feel free to say so!