### PR TITLE
Port all CSS to SCSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"globals": "^16.0.0",
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
+				"sass": "^1.90.0",
 				"svelte": "^5.0.0",
 				"svelte-check": "^4.0.0",
 				"typescript": "^5.0.0",
@@ -1253,6 +1254,330 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/@parcel/watcher": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
+			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"detect-libc": "^1.0.3",
+				"is-glob": "^4.0.3",
+				"micromatch": "^4.0.5",
+				"node-addon-api": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher-android-arm64": "2.5.1",
+				"@parcel/watcher-darwin-arm64": "2.5.1",
+				"@parcel/watcher-darwin-x64": "2.5.1",
+				"@parcel/watcher-freebsd-x64": "2.5.1",
+				"@parcel/watcher-linux-arm-glibc": "2.5.1",
+				"@parcel/watcher-linux-arm-musl": "2.5.1",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.1",
+				"@parcel/watcher-linux-arm64-musl": "2.5.1",
+				"@parcel/watcher-linux-x64-glibc": "2.5.1",
+				"@parcel/watcher-linux-x64-musl": "2.5.1",
+				"@parcel/watcher-win32-arm64": "2.5.1",
+				"@parcel/watcher-win32-ia32": "2.5.1",
+				"@parcel/watcher-win32-x64": "2.5.1"
+			}
+		},
+		"node_modules/@parcel/watcher-android-arm64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
+			"integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-arm64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
+			"integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-darwin-x64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
+			"integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-freebsd-x64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
+			"integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-glibc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
+			"integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm-musl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
+			"integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-glibc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
+			"integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-arm64-musl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
+			"integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-glibc": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
+			"integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-linux-x64-musl": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
+			"integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-arm64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
+			"integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-ia32": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
+			"integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher-win32-x64": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
+			"integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher/node_modules/detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"bin": {
+				"detect-libc": "bin/detect-libc.js"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -3017,6 +3342,13 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/immutable": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3358,6 +3690,14 @@
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
@@ -3783,6 +4123,27 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/sass": {
+			"version": "1.90.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.90.0.tgz",
+			"integrity": "sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^4.0.0",
+				"immutable": "^5.0.2",
+				"source-map-js": ">=0.6.2 <2.0.0"
+			},
+			"bin": {
+				"sass": "sass.js"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"optionalDependencies": {
+				"@parcel/watcher": "^2.4.1"
 			}
 		},
 		"node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"globals": "^16.0.0",
 		"prettier": "^3.4.2",
 		"prettier-plugin-svelte": "^3.3.3",
+		"sass": "^1.90.0",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"typescript": "^5.0.0",

--- a/src/lib/components/ContactCard.svelte
+++ b/src/lib/components/ContactCard.svelte
@@ -27,47 +27,46 @@
 	</div>
 </div>
 
-<style>
+<style lang="scss">
+	@use "$lib/styles/color";
+
 	.contact-card {
 		display: flex;
 		flex-direction: row;
 		gap: 0.5rem;
-	}
 
-	enhanced\:img {
-		width: 8rem;
-		height: 8rem;
-		border-radius: 50%;
-	}
+		img {
+			width: 8rem;
+			height: 8rem;
+			border-radius: 50%;
+		}
 
-	.info {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		min-width: 0; /* Makes info box take only remaining space when small */
-	}
+		.info {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			min-width: 0; // Makes info box take only remaining space when small
 
-	.name {
-		color: var(--heading-fg);
-		font-size: 1.175em;
-		font-weight: bold;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
+			.name {
+				color: color.$green-2;
+				font-size: 1.175em;
+				font-weight: bold;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 
-	.position {
-		margin-bottom: 1em;
-		overflow: hidden;
-		text-overflow: ellipsis;
-	}
+			.position {
+				margin-bottom: 1em;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 
-	.email {
-		/* Clamps the boundaries of the link */
-		width: 100%;
-		align-self: flex-start;
-		overflow: hidden;
-		text-overflow: ellipsis;
+			.email {
+				width: 100%; // Clamps the boundaries of the link
+				align-self: flex-start;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+		}
 	}
-
-	/* Email link is also styled by the global stylesheet */
 </style>

--- a/src/lib/components/DocumentLink.svelte
+++ b/src/lib/components/DocumentLink.svelte
@@ -18,19 +18,21 @@
 	</a>
 </span>
 
-<style>
+<style lang="scss">
+	@use "$lib/styles/color";
+
 	a {
 		display: inline-flex;
 		flex-direction: row;
 		gap: 0.2ch;
 		align-items: center;
-		color: var(--link-btn-fg);
+		color: color.$white;
 		text-decoration: none;
-	}
 
-	.label {
-		padding: 0.2em;
-		border-radius: 0.2rem;
-		background-color: var(--link-btn-bg);
+		.label {
+			padding: 0.2em;
+			border-radius: 0.2rem;
+			background-color: color.$gray-3;
+		}
 	}
 </style>

--- a/src/lib/components/FormField.svelte
+++ b/src/lib/components/FormField.svelte
@@ -39,81 +39,76 @@
 	</div>
 </div>
 
-<style>
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
 	.field {
 		display: inline-flex;
 		flex-direction: column;
-	}
 
-	label {
-		align-self: flex-start;
-		color: var(--input-label-fg);
-	}
+		label {
+			align-self: flex-start;
+		}
 
-	input,
-	select {
-		box-sizing: border-box;
-		width: 100%;
-		padding: 0.5rem;
-		border: 1px solid var(--input-border);
-		border-radius: 0.25rem;
-		background-color: var(--input-bg);
-		color: var(--input-fg);
-		box-shadow: inset 0 1px 3px 1px var(--input-shadow);
-	}
+		.input-container {
+			position: relative;
 
-	.error input,
-	.error select {
-		border-color: var(--error-color);
-	}
+			input,
+			select {
+				width: 100%;
+				box-sizing: border-box;
+			}
 
-	.input-container {
-		position: relative;
-	}
+			.error-tooltip {
+				position: absolute;
+				bottom: calc(100% + 8px);
+				right: 0;
+				padding: 0.2rem 0.4rem;
+				border: 1px solid color.$red;
+				border-radius: 0.25rem;
+				background-color: color.$black-2;
+				color: color.$white;
+				opacity: 0;
+				visibility: hidden;
+				transition: all 100ms ease-out;
 
-	.error-tooltip {
-		position: absolute;
-		bottom: calc(100% + 8px);
-		right: 0;
-		padding: 0.2rem 0.4rem;
-		border: 1px solid var(--error-color);
-		border-radius: 0.25rem;
-		background-color: var(--section-bg);
-		color: var(--section-fg);
-		opacity: 0;
-		visibility: hidden;
-		transition: all 100ms ease-out;
-	}
+				&::after {
+					content: "";
+					position: absolute;
+					top: 100%;
+					left: 25%;
+					border: 8px solid color.$black-2;
+					border-right-color: transparent;
+					border-bottom-color: transparent;
+					border-left-color: transparent;
+				}
 
-	.input-container:hover .error-tooltip {
-		opacity: 1;
-		visibility: visible;
-	}
+				&::before {
+					content: "";
+					position: absolute;
+					top: calc(100% + 1px);
+					left: 25%;
+					border: 8px solid color.$red;
+					border-right-color: transparent;
+					border-bottom-color: transparent;
+					border-left-color: transparent;
+				}
+			}
 
-	input:focus ~ .error-tooltip {
-		opacity: 1;
-		visibility: visible;
-	}
+			&:hover .error-tooltip,
+			input:focus ~ .error-tooltip,
+			select:focus ~ .error-tooltip {
+				opacity: 1;
+				visibility: visible;
+			}
+		}
 
-	.error-tooltip::after {
-		content: "";
-		position: absolute;
-		top: 100%;
-		left: 25%;
-		border: 8px solid var(--section-bg);
-		border-right-color: transparent;
-		border-bottom-color: transparent;
-		border-left-color: transparent;
-	}
-
-	.error-tooltip::before {
-		content: "";
-		position: absolute;
-		top: calc(100% + 1px);
-		left: 25%;
-		border: 8px solid var(--error-color);
-		border-right-color: transparent;
-		border-bottom-color: transparent;
-		border-left-color: transparent;
+		&.error {
+			input,
+			select {
+				border-color: color.$red;
+			}
+		}
 	}
 </style>

--- a/src/lib/components/FormSubmit.svelte
+++ b/src/lib/components/FormSubmit.svelte
@@ -11,23 +11,27 @@
 	{/if}
 </button>
 
-<style>
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
 	button {
+		@include mixin.unified-transition(150ms, ease-out, background-color, color, transform);
+
 		padding: 0.5rem;
 		border: 0;
 		border-radius: 0.25rem;
-		background-color: var(--button-bg);
-		color: var(--button-fg);
-		box-shadow: 0 2px 4px 0 var(--button-shadow);
+		background-color: color.$gray-1;
+		color: color.$green-2;
+		box-shadow: 0 2px 4px 0 color.$shadow;
 		font-size: 1em;
 		font-weight: bold;
 		transform: scaley(1);
-		transition: all 150ms ease-out;
-	}
 
-	button:hover {
-		background-color: var(--button-hover-bg);
-		color: var(--button-hover-fg);
-		transform: scaley(1.1);
+		&:hover {
+			background-color: color.$green-2;
+			color: color.$gray-1;
+			transform: scaley(1.1);
+		}
 	}
 </style>

--- a/src/lib/components/LayoutHeader.svelte
+++ b/src/lib/components/LayoutHeader.svelte
@@ -44,150 +44,140 @@
 	</nav>
 </header>
 
-<style>
-	/* Mobile styling */
-	@media screen and (min-width: 0px) {
-		.mobile {
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
+	header {
+		background-color: color.$green-1;
+		color: color.$green-2;
+
+		&.mobile {
+			$header-height: 4rem;
+
 			display: grid;
+			grid-template-columns: max-content 1fr max-content;
+			position: sticky;
+			top: 0;
+			z-index: 1; // Needed since some elements in <main> mess with the stacking
+
+			@include mixin.on-desktop() {
+				display: none;
+			}
+
+			img {
+				padding: 0.5rem 0;
+				width: 100%;
+				height: $header-height;
+				box-sizing: border-box;
+			}
+
+			button {
+				border: 0;
+				padding: 1rem;
+				width: $header-height;
+				height: $header-height;
+				background-color: transparent;
+
+				svg {
+					width: 100%;
+					height: 100%;
+					fill: color.$green-2;
+				}
+			}
+
+			.nav-backdrop {
+				@include mixin.unified-transition(150ms, ease, opacity, visibility);
+
+				position: fixed;
+				top: $header-height;
+				left: 0;
+				bottom: 0;
+				right: 0;
+				background-color: rgba(0, 0, 0, 0.5);
+
+				&.open {
+					opacity: 1;
+					visibility: visible;
+				}
+
+				&.closed {
+					opacity: 0;
+					visibility: hidden;
+				}
+			}
+
+			nav {
+				@include mixin.unified-transition(150ms, ease, transform);
+
+				display: flex;
+				flex-direction: column;
+				position: fixed;
+				top: $header-height;
+				bottom: 0;
+				min-width: 13rem; // To not look ridiculously small
+				background-color: color.$black-1;
+
+				&.open {
+					transform: translateX(0%);
+				}
+
+				&.closed {
+					transform: translateX(-100%);
+				}
+
+				a {
+					border-bottom: 3px solid rgba(0, 0, 0, 0.35);
+					padding: 1rem;
+					color: color.$green-2;
+					line-height: 1;
+					font-weight: bold;
+					text-decoration: none;
+				}
+			}
 		}
-		.desktop {
-			display: none;
-		}
-	}
 
-	.mobile {
-		/* Display included in media query */
-		grid-template-columns: max-content 1fr max-content;
-		grid-template-areas: "left" "logo" "right";
-		position: sticky;
-		top: 0;
-		/* z-index is needed since the transforms and relative positions
-		   of certain elements in <main> mess with the stacking */
-		z-index: 1;
-		width: 100vw;
-		background-color: var(--header-bg);
-		color: var(--header-fg);
-	}
-
-	.mobile img {
-		margin: 0.5rem 0;
-		width: 100%;
-		height: 3rem;
-		justify-self: center;
-		align-self: center;
-	}
-
-	.mobile button {
-		display: flex;
-		align-items: center;
-		border: 0;
-		padding: 1rem;
-		background-color: transparent;
-	}
-
-	.mobile button svg {
-		height: 2rem;
-		fill: var(--header-fg);
-	}
-
-	.mobile .nav-backdrop {
-		position: fixed;
-		top: 4rem;
-		left: 0;
-		bottom: 0;
-		right: 0;
-		background-color: rgba(0, 0, 0, 0.5);
-		transition:
-			opacity 150ms,
-			visibility 150ms ease;
-	}
-
-	.mobile .nav-backdrop.open {
-		opacity: 1;
-		visibility: visible;
-	}
-
-	.mobile .nav-backdrop.closed {
-		opacity: 0;
-		visibility: hidden;
-	}
-
-	.mobile nav {
-		display: flex;
-		flex-direction: column;
-		position: fixed;
-		top: 4rem;
-		bottom: 0;
-		min-width: 13rem; /* To not look ridiculously small */
-		background-color: var(--bg);
-		transition: transform 150ms ease;
-	}
-
-	.mobile nav.open {
-		transform: translateX(0%);
-	}
-
-	.mobile nav.closed {
-		transform: translateX(-100%);
-	}
-
-	.mobile nav a {
-		border-bottom: 3px solid rgba(0, 0, 0, 0.35);
-		padding: 1rem;
-		color: var(--header-fg);
-		line-height: 1;
-		font-weight: bold;
-		text-decoration: none;
-	}
-
-	/* Desktop styling */
-	@media screen and (min-width: 768px) {
-		.mobile {
-			display: none;
-		}
-		.desktop {
+		&.desktop {
 			display: flex;
+			flex-direction: column;
+			box-sizing: border-box;
+			padding: 2rem;
+
+			@include mixin.on-mobile() {
+				display: none;
+			}
+
+			img {
+				margin-bottom: 1.5rem;
+				width: 100%;
+				height: 4rem;
+			}
+
+			nav {
+				display: flex;
+				flex-direction: row;
+				gap: 1rem;
+				justify-content: center;
+
+				a {
+					@include mixin.unified-transition(150ms, ease, background-color, color, transform);
+
+					padding: 0.5rem 1rem;
+					border: 0.15rem solid color.$green-2;
+					border-radius: 0.5rem;
+					background-color: color.$green-2;
+					color: color.$green-1;
+					line-height: 1;
+					font-weight: bold;
+					text-decoration: none;
+
+					&:hover {
+						background-color: color.$green-1;
+						color: color.$green-2;
+						transform: scale(1.1);
+					}
+				}
+			}
 		}
-	}
-
-	.desktop {
-		/* Display included in media query */
-		flex-direction: column;
-		box-sizing: border-box;
-		padding: 2rem;
-		width: 100vw;
-		background-color: var(--header-bg);
-		color: var(--header-fg);
-	}
-
-	.desktop img {
-		margin-bottom: 1.5rem;
-		max-width: 100%;
-		height: 4rem;
-	}
-
-	.desktop nav {
-		display: flex;
-		flex-direction: row;
-		gap: 1rem;
-		justify-content: center;
-	}
-
-	.desktop nav a {
-		padding: 0.5rem 1rem;
-		border: 0.15rem solid var(--header-fg);
-		border-radius: 0.5rem;
-		background-color: var(--header-fg);
-		color: var(--header-bg);
-		line-height: 1;
-		font-weight: bold;
-		text-decoration: none;
-		transition: all 150ms ease-out;
-	}
-
-	.desktop nav a:hover {
-		background-color: var(--header-bg);
-		color: var(--header-fg);
-		transform: scale(1.1);
 	}
 </style>

--- a/src/lib/components/Section.svelte
+++ b/src/lib/components/Section.svelte
@@ -9,43 +9,32 @@
 	{@render children()}
 </section>
 
-<style>
-	/* Mobile styling */
-	@media screen and (min-width: 0px) {
-		section {
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
+	section {
+		border-radius: 0.5rem;
+		background-color: color.$black-2;
+		color: color.$white;
+
+		@include mixin.on-mobile() {
 			margin: 1rem;
 			padding: 1rem;
-			border-radius: 0.5rem;
-			background-color: var(--section-bg);
-			color: var(--section-fg);
 		}
-	}
 
-	/* Desktop styling */
-	@media screen and (min-width: 768px) {
-		section {
+		@include mixin.on-desktop() {
 			margin: 3rem;
 			padding: 1.5rem;
-			border-radius: 0.5rem;
-			background-color: var(--section-bg);
-			color: var(--section-fg);
+
+			&.thin {
+				margin: 3rem auto;
+				max-width: min(36rem, calc(100% - 6rem)); // Fakes a 3rem horizontal margin
+			}
 		}
 
-		section.thin {
-			margin: 3rem auto;
-			max-width: min(36rem, calc(100% - 6rem)); /* Fakes a 3rem horizontal margin */
+		:global {
+			@include mixin.remove-top-bottom-child-margins();
 		}
-	}
-
-	/* Ensures that there are no unnecessarily large gaps at top or bottom */
-	section > :global(:first-child) {
-		margin-top: 0;
-	}
-	section > :global(:last-child) {
-		margin-bottom: 0;
-	}
-
-	section > :global(:is(h1, h2, h3, h4, h5, h6)) {
-		color: var(--heading-fg);
 	}
 </style>

--- a/src/lib/styles/color.scss
+++ b/src/lib/styles/color.scss
@@ -1,3 +1,31 @@
+/// Color-related variables
+
+// Base colors
+
+$white: #ffffff;
+
+$black-1: #121212;
+$black-2: #1a1a1a;
+
+$gray-1: #232323;
+$gray-2: #2a2a2a;
+$gray-3: #333333;
+$gray-4: #444444;
+$gray-5: #808080;
+
+$green-1: #002200;
+$green-2: #33ff33;
+$green-3: #aaffbf;
+
+$red: #ff3333;
+
+// Specialized colors
+
+$shadow: #00000044;
+
+// Old colors
+// TODO: remove after all other CSS has been converted to SCSS
+
 :root {
 	--bg: #121212;
 	--fg: #ffffff;
@@ -28,35 +56,4 @@
 	--error-color: #ff3333;
 
 	--separator-color: grey;
-}
-
-body {
-	margin: 0;
-	padding: 0;
-	background-color: var(--bg);
-	color: var(--fg);
-	font-family: sans-serif;
-}
-
-a {
-	color: var(--link-fg);
-	text-decoration: none;
-	transition: color 150ms ease-out;
-	fill: var(--link-fg);
-}
-
-a:hover {
-	color: var(--link-hover-fg);
-	fill: var(--link-hover-fg);
-}
-
-a > svg {
-	fill: inherit;
-	transition: fill 150ms ease-out;
-}
-
-hr {
-	border-color: var(--separator-color);
-	border-style: solid;
-	margin: 1rem 0;
 }

--- a/src/lib/styles/color.scss
+++ b/src/lib/styles/color.scss
@@ -22,38 +22,3 @@ $red: #ff3333;
 // Specialized colors
 
 $shadow: #00000044;
-
-// Old colors
-// TODO: remove after all other CSS has been converted to SCSS
-
-:root {
-	--bg: #121212;
-	--fg: #ffffff;
-	--header-bg: #002200;
-	--header-fg: #33ff33;
-	--section-bg: #1a1a1a;
-	--section-fg: #ffffff;
-
-	--heading-fg: #33ff33;
-
-	--link-fg: #33ff33;
-	--link-hover-fg: #aaffbf;
-
-	--link-btn-bg: #333333;
-	--link-btn-fg: #ffffff;
-
-	--input-label-fg: #33ff33;
-	--input-bg: #333333;
-	--input-border: #444444;
-	--input-fg: #33ff33;
-	--input-shadow: #00000044;
-	--button-bg: #232323;
-	--button-fg: #33ff33;
-	--button-shadow: #00000044;
-	--button-hover-bg: var(--button-fg);
-	--button-hover-fg: var(--button-bg);
-	--success-color: #33ff33;
-	--error-color: #ff3333;
-
-	--separator-color: grey;
-}

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -32,3 +32,9 @@ hr {
 	margin: 1rem 0;
 	border: 1px solid color.$gray-5;
 }
+
+img {
+	// Necessary for enhanced images to scale identically to normal images
+	width: auto;
+	height: auto;
+}

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -47,3 +47,17 @@ h5,
 h6 {
 	color: color.$green-2;
 }
+
+label {
+	color: color.$green-2;
+}
+
+input,
+select {
+	border: 1px solid color.$gray-4;
+	padding: 0.5rem;
+	border-radius: 0.25rem;
+	background-color: color.$gray-3;
+	color: color.$green-2;
+	box-shadow: inset 0 1px 3px 1px color.$shadow;
+}

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -1,0 +1,34 @@
+/// Default styles for HTML elements
+
+@use "color";
+@use "mixin";
+
+body {
+	margin: 0;
+	padding: 0;
+	background-color: color.$black-1;
+	color: color.$white;
+	font-family: sans-serif;
+}
+
+a {
+	@include mixin.unified-transition(150ms, ease-out, color, fill);
+
+	color: color.$green-2;
+	fill: color.$green-2;
+	text-decoration: none;
+
+	svg {
+		fill: inherit;
+	}
+
+	&:hover {
+		color: color.$green-3;
+		fill: color.$green-3;
+	}
+}
+
+hr {
+	margin: 1rem 0;
+	border: 1px solid color.$gray-5;
+}

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -38,3 +38,12 @@ img {
 	width: auto;
 	height: auto;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+	color: color.$green-2;
+}

--- a/src/lib/styles/mixin.scss
+++ b/src/lib/styles/mixin.scss
@@ -19,3 +19,13 @@
 		@content;
 	}
 }
+
+@mixin remove-top-bottom-child-margins() {
+	> *:first-child {
+		margin-top: 0;
+	}
+
+	> *:last-child {
+		margin-bottom: 0;
+	}
+}

--- a/src/lib/styles/mixin.scss
+++ b/src/lib/styles/mixin.scss
@@ -1,0 +1,7 @@
+/// Mixins for commonly used property sets
+
+@mixin unified-transition($duration, $timing-function, $properties...) {
+	transition-duration: $duration;
+	transition-timing-function: $timing-function;
+	transition-property: $properties;
+}

--- a/src/lib/styles/mixin.scss
+++ b/src/lib/styles/mixin.scss
@@ -1,7 +1,21 @@
-/// Mixins for commonly used property sets
+/// Mixins for commonly used styles
+
+@use "size";
 
 @mixin unified-transition($duration, $timing-function, $properties...) {
 	transition-duration: $duration;
 	transition-timing-function: $timing-function;
 	transition-property: $properties;
+}
+
+@mixin on-desktop() {
+	@media screen and (min-width: size.$min-desktop-width) {
+		@content;
+	}
+}
+
+@mixin on-mobile() {
+	@media screen and (max-width: size.$max-mobile-width) {
+		@content;
+	}
 }

--- a/src/lib/styles/size.scss
+++ b/src/lib/styles/size.scss
@@ -1,0 +1,4 @@
+/// Size-related variables
+
+$min-desktop-width: 768px;
+$max-mobile-width: calc($min-desktop-width - 1px);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from "svelte";
-	import "$lib/styles/global.css"; // This stylesheet affects the entire site.
+	import "$lib/styles/default.scss"; // This stylesheet affects the entire site.
 	import LayoutHeader from "$lib/components/LayoutHeader.svelte";
 
 	interface LayoutProps {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,7 +23,7 @@
 
 <main>{@render children()}</main>
 
-<style>
+<style lang="scss">
 	main {
 		width: 100vw;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -146,19 +146,17 @@
 	</div>
 </Section>
 
-<style>
-	/* Mobile styling */
-	@media screen and (min-width: 0px) {
-		.contact-grid {
+<style lang="scss">
+	@use "$lib/styles/mixin";
+
+	.contact-grid {
+		@include mixin.on-mobile() {
 			display: flex;
 			flex-direction: column;
 			gap: 1rem;
 		}
-	}
 
-	/* Desktop styling */
-	@media screen and (min-width: 768px) {
-		.contact-grid {
+		@include mixin.on-desktop() {
 			display: grid;
 			gap: 1rem;
 			grid-template-columns: repeat(auto-fill, minmax(26rem, 1fr));
@@ -175,9 +173,9 @@
 		display: flex;
 		flex-direction: row;
 		gap: 0.5rem;
-	}
 
-	.social-medias svg {
-		height: 2rem;
+		svg {
+			height: 2rem;
+		}
 	}
 </style>

--- a/src/routes/christmas-2024/+page.svelte
+++ b/src/routes/christmas-2024/+page.svelte
@@ -87,77 +87,82 @@
 	{/if}
 </Section>
 
-<style>
+<style lang="scss">
+	@use "$lib/styles/color";
+
 	table {
 		width: 100%;
 		border-spacing: 0;
-	}
 
-	thead,
-	tbody {
-		box-shadow: 0 2px 4px 0 #00000044;
-	}
+		thead,
+		tbody {
+			box-shadow: 0 2px 4px 0 #00000044;
 
-	td {
-		padding: 0.25rem;
-		text-align: center;
-	}
+			td {
+				padding: 0.25rem;
+				text-align: center;
 
-	thead td {
-		border: 1px solid #333333;
-		background-color: #232323;
-	}
+				&:not(:last-child) {
+					border-right: none;
+				}
+			}
 
-	thead td:first-child {
-		border-top-left-radius: 0.25rem;
-		border-bottom-left-radius: 0.25rem;
-	}
+			tr {
+				&:not(:first-child) td {
+					border-top: none;
+				}
 
-	thead td:last-child {
-		border-top-right-radius: 0.25rem;
-		border-bottom-right-radius: 0.25rem;
-	}
+				&:first-child td {
+					&:first-child {
+						border-top-left-radius: 0.25rem;
+					}
 
-	tbody:before {
-		content: "-";
-		display: block;
-		line-height: 0.25rem;
-		color: transparent;
-	}
+					&:last-child {
+						border-top-right-radius: 0.25rem;
+					}
+				}
 
-	tbody td {
-		border: 1px solid #444444;
-	}
+				&:last-child td {
+					&:first-child {
+						border-bottom-left-radius: 0.25rem;
+					}
 
-	tbody tr:not(:first-child) td {
-		border-top: none;
-	}
+					&:last-child {
+						border-bottom-right-radius: 0.25rem;
+					}
+				}
+			}
+		}
 
-	tbody tr:nth-child(odd) td {
-		background-color: #2a2a2a;
-	}
+		thead {
+			td {
+				border: 1px solid #333333;
+				background-color: #232323;
+			}
+		}
 
-	tbody tr:nth-child(even) td {
-		background-color: #333333;
-	}
+		tbody {
+			&:before {
+				// Adds space between <thead> and <tbody>
+				content: "-";
+				display: block;
+				color: transparent;
+				line-height: 0.25rem;
+			}
 
-	tbody tr:first-child td:first-child {
-		border-top-left-radius: 0.25rem;
-	}
+			td {
+				border: 1px solid #444444;
+			}
 
-	tbody tr:first-child td:last-child {
-		border-top-right-radius: 0.25rem;
-	}
+			tr {
+				&:nth-child(odd) td {
+					background-color: #2a2a2a;
+				}
 
-	tbody tr:last-child td:first-child {
-		border-bottom-left-radius: 0.25rem;
-	}
-
-	tbody tr:last-child td:last-child {
-		border-bottom-right-radius: 0.25rem;
-	}
-
-	td:not(:last-child) {
-		border-right: none;
+				&:nth-child(even) td {
+					background-color: #333333;
+				}
+			}
+		}
 	}
 </style>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -236,7 +236,6 @@
 
 		h1 {
 			margin-top: 0;
-			color: color.$green-2;
 		}
 	}
 

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -206,8 +206,11 @@
 	</div>
 </Section>
 
-<style>
-	enhanced\:img,
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
+	// TODO: create global default for images
 	img {
 		max-width: 100%;
 		height: auto;
@@ -220,46 +223,39 @@
 		gap: 1rem;
 		justify-content: center;
 		margin: 1rem 0;
-	}
 
-	.sponsor-logos enhanced\:img,
-	.sponsor-logos img {
-		width: auto;
-		height: 2rem;
+		img {
+			width: auto;
+			height: 2rem;
+		}
 	}
 
 	.past-event {
 		opacity: 0.5;
-	}
 
-	.past-event img {
-		filter: saturate(50%);
-	}
+		img {
+			filter: saturate(50%);
+		}
 
-	.past-event h1 {
-		margin-top: 0;
-		color: var(--header-fg);
-	}
-
-	/* Mobile styling */
-	@media screen and (min-width: 0px) {
-		.section-header {
-			font-size: 1.75rem;
-			color: var(--heading-fg);
-			margin: 1rem 1.25rem;
-			max-width: min(36rem, calc(100% - 6rem));
+		h1 {
+			margin-top: 0;
+			color: color.$green-2;
 		}
 	}
 
-	/* Desktop styling */
-	@media screen and (min-width: 768px) {
-		.section-header {
-			font-size: 1.75rem;
-			color: var(--heading-fg);
+	.section-header {
+		font-size: 1.75rem;
+		color: color.$green-2;
+		max-width: min(36rem, calc(100% - 6rem));
+
+		@include mixin.on-mobile() {
+			margin: 1rem 1.25rem;
+		}
+
+		@include mixin.on-desktop() {
 			margin-top: 3rem;
 			margin-bottom: -2rem;
-			margin-left: calc(50% - min(18rem, 50% - 3rem) - 1.25rem); /* This feels very hacky */
-			max-width: min(36rem, calc(100% - 6rem));
+			margin-left: calc(50% - min(18rem, 50% - 3rem) - 1.25rem); // This feels very hacky
 		}
 	}
 </style>

--- a/src/routes/events/+page.svelte
+++ b/src/routes/events/+page.svelte
@@ -210,10 +210,8 @@
 	@use "$lib/styles/color";
 	@use "$lib/styles/mixin";
 
-	// TODO: create global default for images
 	img {
 		max-width: 100%;
-		height: auto;
 	}
 
 	.sponsor-logos {
@@ -225,7 +223,6 @@
 		margin: 1rem 0;
 
 		img {
-			width: auto;
 			height: 2rem;
 		}
 	}

--- a/src/routes/new-member/+page.svelte
+++ b/src/routes/new-member/+page.svelte
@@ -104,31 +104,33 @@
 	{/if}
 </Section>
 
-<style>
+<style lang="scss">
+	@use "$lib/styles/color";
+
 	form {
 		display: grid;
 		grid-template-columns: 1fr 1fr;
 		grid-template-rows: 1fr 1fr 1fr 1fr;
 		gap: 0.8rem;
-	}
 
-	form > :global(:nth-child(3)),
-	form > :global(:nth-child(4)) {
-		grid-column: 1 / span 2;
-	}
+		> :global(:nth-child(3)),
+		> :global(:nth-child(4)) {
+			grid-column: 1 / span 2;
+		}
 
-	form > :global(:nth-child(5)) {
-		grid-column: 1 / span 2;
-		align-self: flex-end;
+		> :global(:nth-child(5)) {
+			grid-column: 1 / span 2;
+			align-self: flex-end;
+		}
 	}
 
 	.success-msg {
-		color: var(--success-color);
+		color: color.$green-2;
 		text-align: center;
 	}
 
 	.error-msg {
-		color: var(--error-color);
+		color: color.$red;
 		text-align: center;
 	}
 </style>


### PR DESCRIPTION
This PR ports all CSS to SCSS, makes the designs of headings and form elements global, and also fixes some bugs that went unnoticed due to not using nesting and variables as much before. Other than the changes caused by the bug fixes, everything looks the same as it did before.

All selectors including "enhanced\\:img" have been removed or changed to "img". The [docs](https://svelte.dev/docs/kit/images#sveltejs-enhanced-img-Basic-usage) state that you need to write "enhanced\\:img", but I noticed no difference when testing both the development and build version of the website.