### PR TITLE
Add link to 2025 annual meeting protocol

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -187,6 +187,7 @@
 		<div class="document-list">
 			<DocumentLink link={getAssetUrl("documents/lithe_hax_stadgar_uppdaterad.pdf")} />
 			<DocumentLink link={getAssetUrl("documents/lithe_hax_konstituerande_protokoll.pdf")} />
+			<DocumentLink link={getAssetUrl("documents/lithe_hax_arsmote_2025.pdf")} />
 		</div>
 	</Article>
 </ArticleGroup>


### PR DESCRIPTION
This PR adds a link to the 2025 annual meeting protocol on the home page.