### PR TITLE
Show clear error if user is already a member

### DIFF
--- a/src/lib/components/forms/MembershipApplicationForm.svelte
+++ b/src/lib/components/forms/MembershipApplicationForm.svelte
@@ -47,6 +47,8 @@
 					if ("email" in data) {
 						let mainError = (data.email as string[])[0];
 						emailError = mainError;
+						// The only server-side error that occurs for emails is that it's already used
+						errorMessage = "A member has already applied with that email!";
 					}
 					if ("is_student" in data) {
 						let mainError = (data.is_student as string[])[0];


### PR DESCRIPTION
This PR adds a clear message if a user has already applied for a membership before, since many users have been confused about that before.