### PR TITLE
Convert global styles to local styles

### DIFF
--- a/src/lib/components/ContactCard.svelte
+++ b/src/lib/components/ContactCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import getAssetUrl from "$lib/api/asset";
+	import Link from "$lib/components/Link.svelte";
 
 	type Props = {
 		fullName: string;
@@ -23,11 +24,13 @@
 			{#if hackerTag}@{hackerTag}{/if}
 		</span>
 		<span class="position">{position}</span>
-		{#if email !== undefined}
-			<a class="email" href={`mailto:${email}`}>{email}</a>
-		{:else}
-			<span class="email">(mail coming soon)</span>
-		{/if}
+		<span class="email">
+			{#if email !== undefined}
+				<Link href={`mailto:${email}`}>{email}</Link>
+			{:else}
+				(mail coming soon)
+			{/if}
+		</span>
 	</div>
 </div>
 

--- a/src/lib/components/EventArticle.svelte
+++ b/src/lib/components/EventArticle.svelte
@@ -7,6 +7,7 @@
 	import Article from "./Article.svelte";
 	import DocumentLink from "./DocumentLink.svelte";
 	import Heading from "./Heading.svelte";
+	import Link from "./Link.svelte";
 	import Separator from "./Separator.svelte";
 
 	type Props = { event: Event };
@@ -74,7 +75,7 @@
 		{#if event.location}
 			<span>
 				<i class="fa-solid fa-location-dot fa-width-auto"></i>
-				<a href={event.location.maps_url}>{event.location.name}</a>
+				<Link href={event.location.maps_url}>{event.location.name}</Link>
 			</span>
 		{/if}
 	</div>
@@ -89,7 +90,7 @@
 				<!-- Matches HTTP(S) URLs with paths that ends with a dot and some alphanumerics -->
 				<DocumentLink link={href} />
 			{:else if children}
-				<a {href} {...restProps}>{@render children()}</a>
+				<Link {href} {...restProps}>{@render children()}</Link>
 			{/if}
 		{/snippet}
 		{#snippet img(props)}

--- a/src/lib/components/EventArticle.svelte
+++ b/src/lib/components/EventArticle.svelte
@@ -6,6 +6,7 @@
 
 	import Article from "./Article.svelte";
 	import DocumentLink from "./DocumentLink.svelte";
+	import Heading from "./Heading.svelte";
 
 	type Props = { event: Event };
 
@@ -46,8 +47,8 @@
 </script>
 
 <Article>
-	<h1 class="title">{event.title}</h1>
-	<div class="info-row">
+	<Heading level={1} content={event.title} />
+	<div class="info-row" style:margin-top="-1.15rem">
 		<span>
 			<i class="fa-solid fa-calendar fa-width-auto"></i>
 			{#if endDate && event.show_time}
@@ -107,10 +108,6 @@
 
 <style lang="scss">
 	@use "$lib/styles/color";
-
-	.title {
-		margin-bottom: 0.2rem;
-	}
 
 	.info-row {
 		display: flex;

--- a/src/lib/components/EventArticle.svelte
+++ b/src/lib/components/EventArticle.svelte
@@ -7,6 +7,7 @@
 	import Article from "./Article.svelte";
 	import DocumentLink from "./DocumentLink.svelte";
 	import Heading from "./Heading.svelte";
+	import Separator from "./Separator.svelte";
 
 	type Props = { event: Event };
 
@@ -97,7 +98,7 @@
 	</Markdown>
 
 	{#if event.sponsors.length != 0}
-		<hr />
+		<Separator />
 		<div class="sponsor-logos">
 			{#each event.sponsors as sponsor (sponsor.name)}
 				<img src={sponsor.logo_url} alt={`logo of ${sponsor.name}`} />

--- a/src/lib/components/Heading.svelte
+++ b/src/lib/components/Heading.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	type HeadingProps = {
+		content: string;
+		level: 1 | 2 | 3 | 4 | 5 | 6;
+	};
+
+	const { content, level }: HeadingProps = $props();
+</script>
+
+{#if level === 1}
+	<h1>{content}</h1>
+{:else if level === 2}
+	<h2>{content}</h2>
+{:else if level === 3}
+	<h3>{content}</h3>
+{:else if level === 4}
+	<h4>{content}</h4>
+{:else if level === 5}
+	<h5>{content}</h5>
+{:else}
+	<h6>{content}</h6>
+{/if}
+
+<style lang="scss">
+	@use "$lib/styles/color";
+
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6 {
+		color: color.$green-2;
+	}
+</style>

--- a/src/lib/components/Link.svelte
+++ b/src/lib/components/Link.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { HTMLAnchorAttributes } from "svelte/elements";
+
+	type LinkProps = HTMLAnchorAttributes;
+
+	const { children, ...restProps }: LinkProps = $props();
+</script>
+
+<a {...restProps}>{@render children?.()}</a>
+
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
+	a {
+		@include mixin.unified-transition(150ms, ease-out, color, fill);
+
+		color: color.$green-2;
+		fill: color.$green-2;
+		text-decoration: none;
+
+		:global(svg) {
+			fill: inherit;
+		}
+
+		&:hover {
+			color: color.$green-3;
+			fill: color.$green-3;
+		}
+	}
+</style>

--- a/src/lib/components/Pagination.svelte
+++ b/src/lib/components/Pagination.svelte
@@ -74,6 +74,7 @@
 			color: color.$green-2;
 			font-weight: bold;
 			line-height: 1;
+			text-decoration: none;
 
 			&.selected {
 				background-color: color.$green-2;

--- a/src/lib/components/Separator.svelte
+++ b/src/lib/components/Separator.svelte
@@ -1,0 +1,10 @@
+<hr />
+
+<style lang="scss">
+	@use "$lib/styles/color";
+
+	hr {
+		margin: 1rem 0;
+		border: 1px solid color.$gray-5;
+	}
+</style>

--- a/src/lib/components/forms/MembershipApplicationForm.svelte
+++ b/src/lib/components/forms/MembershipApplicationForm.svelte
@@ -5,6 +5,7 @@
 	import TextInput from "../inputs/TextInput.svelte";
 	import DropdownInput from "../inputs/DropdownInput.svelte";
 	import FormStatusOverlay from "./FormStatusOverlay.svelte";
+	import Button from "../inputs/Button.svelte";
 
 	let firstName = $state("");
 	let lastName = $state("");
@@ -86,7 +87,7 @@
 		label="Membership Type"
 		error={membershipTypeError}
 	/>
-	<button type="submit" disabled={isSubmitting}>Apply for membership</button>
+	<Button type="submit" disabled={isSubmitting}>Apply for membership</Button>
 	<FormStatusOverlay {isSubmitting} {errorMessage} successMessage="Applied for a membership" />
 </form>
 

--- a/src/lib/components/inputs/Button.svelte
+++ b/src/lib/components/inputs/Button.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import type { HTMLButtonAttributes } from "svelte/elements";
+
+	type ButtonProps = HTMLButtonAttributes;
+
+	const { children, ...restProps }: ButtonProps = $props();
+</script>
+
+<button {...restProps}>{@render children?.()}</button>
+
+<style lang="scss">
+	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
+
+	button {
+		@include mixin.unified-transition(150ms, ease-out, background-color, color, transform);
+
+		border: 0;
+		padding: 0.5rem;
+		border-radius: 0.25rem;
+		background-color: color.$gray-1;
+		color: color.$green-2;
+		box-shadow: 0 2px 4px 0 color.$shadow;
+		font-family: inherit;
+		font-size: 1em;
+		font-weight: bold;
+		transform: scaley(1);
+
+		&:hover {
+			background-color: color.$green-2;
+			color: color.$gray-1;
+			transform: scaley(1.1);
+		}
+	}
+</style>

--- a/src/lib/components/inputs/DropdownInput.svelte
+++ b/src/lib/components/inputs/DropdownInput.svelte
@@ -2,6 +2,7 @@
 	import type { HTMLSelectAttributes } from "svelte/elements";
 	import type { InputProps } from "$lib/types";
 	import ErrorTooltip from "$lib/components/inputs/ErrorTooltip.svelte";
+	import Label from "./Label.svelte";
 
 	type Option = { label: string; value: string };
 	type Props = HTMLSelectAttributes & InputProps & { options: Option[] };
@@ -12,7 +13,7 @@
 
 <div class={["dropdown-input", error && "error"]}>
 	{#if label}
-		<label for={uid}>{label}</label>
+		<Label for={uid}>{label}</Label>
 	{/if}
 
 	<div class="tooltip-container">

--- a/src/lib/components/inputs/DropdownInput.svelte
+++ b/src/lib/components/inputs/DropdownInput.svelte
@@ -31,6 +31,7 @@
 
 <style lang="scss">
 	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
 
 	.dropdown-input {
 		display: inline-flex;
@@ -44,6 +45,8 @@
 			}
 
 			select {
+				@include mixin.text-input();
+
 				width: 100%;
 				box-sizing: border-box;
 			}

--- a/src/lib/components/inputs/Label.svelte
+++ b/src/lib/components/inputs/Label.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import type { HTMLLabelAttributes } from "svelte/elements";
+
+	type LabelProps = HTMLLabelAttributes;
+
+	const { children, ...restProps }: LabelProps = $props();
+</script>
+
+<label {...restProps}>{@render children?.()}</label>
+
+<style lang="scss">
+	@use "$lib/styles/color";
+
+	label {
+		color: color.$green-2;
+	}
+</style>

--- a/src/lib/components/inputs/TextInput.svelte
+++ b/src/lib/components/inputs/TextInput.svelte
@@ -27,6 +27,7 @@
 
 <style lang="scss">
 	@use "$lib/styles/color";
+	@use "$lib/styles/mixin";
 
 	.text-input {
 		display: inline-flex;
@@ -40,6 +41,8 @@
 			position: relative;
 
 			input {
+				@include mixin.text-input();
+
 				width: 100%;
 				box-sizing: border-box;
 			}

--- a/src/lib/components/inputs/TextInput.svelte
+++ b/src/lib/components/inputs/TextInput.svelte
@@ -2,6 +2,7 @@
 	import type { HTMLInputAttributes } from "svelte/elements";
 	import type { InputProps } from "$lib/types";
 	import ErrorTooltip from "$lib/components/inputs/ErrorTooltip.svelte";
+	import Label from "./Label.svelte";
 
 	type AllowedType = "text" | "email" | "number";
 	type Props = HTMLInputAttributes & InputProps & { type: AllowedType };
@@ -12,7 +13,7 @@
 
 <div class={["text-input", error && "error"]}>
 	{#if label}
-		<label for={uid}>{label}</label>
+		<Label for={uid}>{label}</Label>
 	{/if}
 
 	<div class="tooltip-container">

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -11,23 +11,6 @@ body {
 	font-family: "Fira Sans", sans-serif;
 }
 
-a {
-	@include mixin.unified-transition(150ms, ease-out, color, fill);
-
-	color: color.$green-2;
-	fill: color.$green-2;
-	text-decoration: none;
-
-	svg {
-		fill: inherit;
-	}
-
-	&:hover {
-		color: color.$green-3;
-		fill: color.$green-3;
-	}
-}
-
 label {
 	color: color.$green-2;
 }

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -13,15 +13,5 @@ body {
 
 input,
 select {
-	font-family: inherit;
-}
-
-input,
-select {
-	border: 1px solid color.$gray-4;
-	padding: 0.5rem;
-	border-radius: 0.25rem;
-	background-color: color.$gray-3;
-	color: color.$green-2;
-	box-shadow: inset 0 1px 3px 1px color.$shadow;
+	@include mixin.text-input();
 }

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -28,11 +28,6 @@ a {
 	}
 }
 
-hr {
-	margin: 1rem 0;
-	border: 1px solid color.$gray-5;
-}
-
 img {
 	// Necessary for enhanced images to scale identically to normal images
 	width: auto;

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -39,15 +39,6 @@ img {
 	height: auto;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	color: color.$green-2;
-}
-
 label {
 	color: color.$green-2;
 }

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -16,8 +16,7 @@ label {
 }
 
 input,
-select,
-button {
+select {
 	font-family: inherit;
 }
 
@@ -29,27 +28,4 @@ select {
 	background-color: color.$gray-3;
 	color: color.$green-2;
 	box-shadow: inset 0 1px 3px 1px color.$shadow;
-}
-
-input[type="button"],
-input[type="submit"],
-input[type="reset"],
-button {
-	@include mixin.unified-transition(150ms, ease-out, background-color, color, transform);
-
-	border: 0;
-	padding: 0.5rem;
-	border-radius: 0.25rem;
-	background-color: color.$gray-1;
-	color: color.$green-2;
-	box-shadow: 0 2px 4px 0 color.$shadow;
-	font-size: 1em;
-	font-weight: bold;
-	transform: scaley(1);
-
-	&:hover {
-		background-color: color.$green-2;
-		color: color.$gray-1;
-		transform: scaley(1.1);
-	}
 }

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -11,10 +11,6 @@ body {
 	font-family: "Fira Sans", sans-serif;
 }
 
-label {
-	color: color.$green-2;
-}
-
 input,
 select {
 	font-family: inherit;

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -28,12 +28,6 @@ a {
 	}
 }
 
-img {
-	// Necessary for enhanced images to scale identically to normal images
-	width: auto;
-	height: auto;
-}
-
 label {
 	color: color.$green-2;
 }

--- a/src/lib/styles/default.scss
+++ b/src/lib/styles/default.scss
@@ -10,8 +10,3 @@ body {
 	color: color.$white;
 	font-family: "Fira Sans", sans-serif;
 }
-
-input,
-select {
-	@include mixin.text-input();
-}

--- a/src/lib/styles/mixin.scss
+++ b/src/lib/styles/mixin.scss
@@ -1,5 +1,6 @@
 /// Mixins for commonly used styles
 
+@use "color";
 @use "size";
 
 @mixin unified-transition($duration, $timing-function, $properties...) {
@@ -28,4 +29,14 @@
 	> *:last-child {
 		margin-bottom: 0;
 	}
+}
+
+@mixin text-input() {
+	border: 1px solid color.$gray-4;
+	padding: 0.5rem;
+	border-radius: 0.25rem;
+	background-color: color.$gray-3;
+	color: color.$green-2;
+	box-shadow: inset 0 1px 3px 1px color.$shadow;
+	font-family: inherit;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import ArticleGroup from "$lib/components/ArticleGroup.svelte";
 	import ContactCard from "$lib/components/ContactCard.svelte";
 	import DocumentLink from "$lib/components/DocumentLink.svelte";
+	import Heading from "$lib/components/Heading.svelte";
 	import PageHead from "$lib/components/PageHead.svelte";
 </script>
 
@@ -15,7 +16,7 @@
 
 <ArticleGroup>
 	<Article>
-		<h1>About Us</h1>
+		<Heading level={1} content="About Us" />
 		<p>
 			LiTHe Hax is an independent student association at Linköping University whose purpose is to
 			promote and strengthen knowledge in ethical hacking and cybersecurity. The association is
@@ -40,7 +41,7 @@
 			></a>
 		</div>
 
-		<h2>The Board</h2>
+		<Heading level={2} content="The Board" />
 		<p>
 			The board is responsible for communicating with partners and sponsors, arranging and marketing
 			events, as well as handling other administrative tasks.
@@ -118,7 +119,7 @@
 			/>
 		</div>
 
-		<h2>The CTF Committee</h2>
+		<Heading level={2} content="The CTF Committee" />
 		<p>
 			The CTF committee is responsible for helping the board with arranging CTF events, as well as
 			designing exciting and challenging exercises for participants.
@@ -176,14 +177,14 @@
 			/>
 		</div>
 
-		<h2>Organization Details</h2>
+		<Heading level={2} content="Organization Details" />
 		<p>
 			<b>Organization Number:</b> 802547-1767
 			<br />
 			<b>Adress:</b> LiTHe Hax, Kårallen, Universitetet, 581 83 Linköping
 		</p>
 
-		<h3>Documents</h3>
+		<Heading level={3} content="Documents" />
 		<div class="document-list">
 			<DocumentLink link={getAssetUrl("documents/lithe_hax_stadgar_uppdaterad.pdf")} />
 			<DocumentLink link={getAssetUrl("documents/lithe_hax_konstituerande_protokoll.pdf")} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import ContactCard from "$lib/components/ContactCard.svelte";
 	import DocumentLink from "$lib/components/DocumentLink.svelte";
 	import Heading from "$lib/components/Heading.svelte";
+	import Link from "$lib/components/Link.svelte";
 	import PageHead from "$lib/components/PageHead.svelte";
 </script>
 
@@ -24,21 +25,15 @@
 			participate in LiTHe Hax's activities. The association was founded on March 29, 2024.
 		</p>
 		<div class={["social-medias", "fa-width-auto"]}>
-			<a
-				class={["fa-brands", "fa-discord"]}
-				href="https://discord.gg/UykWT8W899"
-				aria-label="discord"
-			></a>
-			<a
-				class={["fa-brands", "fa-facebook"]}
-				href="https://www.facebook.com/profile.php?id=61567434623373"
-				aria-label="facebook"
-			></a>
-			<a
-				class={["fa-brands", "fa-instagram"]}
-				href="https://www.instagram.com/lithehax?utm_source=ig_web_button_share_sheet&igsh=ZDNlZDc0MzIxNw=="
-				aria-label="instagram"
-			></a>
+			<Link href="https://discord.gg/UykWT8W899" aria-label="Discord">
+				<i class={["fa-brands", "fa-discord"]}></i>
+			</Link>
+			<Link href="https://www.facebook.com/profile.php?id=61567434623373" aria-label="Facebook">
+				<i class={["fa-brands", "fa-facebook"]}></i>
+			</Link>
+			<Link href="https://www.instagram.com/lithehax" aria-label="Instagram">
+				<i class={["fa-brands", "fa-instagram"]}></i>
+			</Link>
 		</div>
 
 		<Heading level={2} content="The Board" />

--- a/src/routes/christmas-2024/+page.svelte
+++ b/src/routes/christmas-2024/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Article from "$lib/components/Article.svelte";
 	import ArticleGroup from "$lib/components/ArticleGroup.svelte";
+	import Heading from "$lib/components/Heading.svelte";
 	import PageHead from "$lib/components/PageHead.svelte";
 
 	type LeaderboardRow = [string, string];
@@ -62,7 +63,7 @@
 
 <ArticleGroup layout="thin">
 	<Article>
-		<h1>Christmas CTF 2024 Leaderboard</h1>
+		<Heading level={1} content="Christmas CTF 2024 Leaderboard" />
 		{#if hasError}
 			<p>Could not load leaderboard, try again later.</p>
 		{:else if leaderboardRows === undefined}

--- a/src/routes/new-member/+page.svelte
+++ b/src/routes/new-member/+page.svelte
@@ -2,6 +2,7 @@
 	import Article from "$lib/components/Article.svelte";
 	import ArticleGroup from "$lib/components/ArticleGroup.svelte";
 	import MembershipApplicationForm from "$lib/components/forms/MembershipApplicationForm.svelte";
+	import Heading from "$lib/components/Heading.svelte";
 	import PageHead from "$lib/components/PageHead.svelte";
 </script>
 
@@ -12,7 +13,7 @@
 
 <ArticleGroup layout="thin">
 	<Article>
-		<h1>Become a member</h1>
+		<Heading level={1} content="Become a Member" />
 		<p>
 			Join LiTHe Hax and become a member! As a member, you'll gain access to exclusive events,
 			resources, and updates about our organization's activities. Once your membership is approved


### PR DESCRIPTION
This PR converts global styles in `default.scss` to local styles by creating a component for them or moving them to an already existing component. There are two reasons for doing this:

1. Global styles are less predictable and may affect component and elements unintentionally. This has happened before with the mobile nav toggle button. Local styles prevent this from happening by only affecting element local to the file the style is defined in.
2. It makes it easier to redesign the website incrementally (as is going to be done in issue #72), since components can be redesigned one at a time.